### PR TITLE
Add support for saving/restoring image layers from archive

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -9,6 +9,9 @@ The following parameters are used to configure this plugin:
 * `tag` - repository tag for the image
 * `insecure` - enable insecure communication to this registry
 * `storage_driver` - use `aufs`, `devicemapper`, `btrfs` or `overlay` driver
+* `archive` - save and restore image layers to/from a tarred archive
+    * `file` - absolute or relative path to archive file
+    * `tag` - limit archiving to these tag(s) (optional)
 
 The following is a sample Docker configuration in your .drone.yml file:
 
@@ -52,6 +55,27 @@ publish:
 ```
 
 Note that in the above example we quote the version numbers. If the yaml parser interprets the value as a number it will cause a parsing error.
+
+You may want to cache Docker image layers between builds to speed up the build process:
+
+```
+publish:
+  docker:
+    username: kevinbacon
+    password: $$DOCKER_PASSWORD
+    email: kevin.bacon@mail.com
+    repo: foo/bar
+    tag:
+      - latest
+      - "1.0.1"
+    archive:
+      file: docker/image.tar
+      tag: latest
+
+cache:
+  mount:
+    - docker/image.tar
+```
 
 ## Troubleshooting
 


### PR DESCRIPTION
This PR adds support to the Docker plugin for saving/restoring Docker image layers to/from an archive file. Combined with the cache plugin it enables caching of image layers between builds.

Adds a new parameter:

##### `archive`
Create a tarred repository containing all layers of the Docker image and restore the image repository on consecutive builds.
The `archive` value must be a dictionary defined with a required `file` and an optional `tag` key.

`file` can either be an absolute path starting with `/drone` or a relative path which will be expanded from the working directory.
`tag` allows limiting the export of the image layers to the supplied tag(s).

```yaml
archive:
  file: docker/image.tar
  tag: latest
```

##### Example usage:

```yaml
publish:
  docker:
    username: kevinbacon
    password: $$DOCKER_PASSWORD
    email: kevin.bacon@mail.com
    repo: foo/bar
    tag:
      - latest
      - "1.0.1"
    archive:
      file: docker/image.tar
      tag: latest

cache:
  mount:
    - docker/image.tar
```

