### PR TITLE
Adding support to registry mirroring

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -8,6 +8,7 @@ The following parameters are used to configure this plugin:
 * `repo` - repository name for the image
 * `tag` - repository tag for the image
 * `insecure` - enable insecure communication to this registry
+* `mirror` - use a mirror registry instead of pulling images directly from the central Hub
 * `storage_driver` - use `aufs`, `devicemapper`, `btrfs` or `overlay` driver
 * `archive` - save and restore image layers to/from a tarred archive
     * `file` - absolute or relative path to archive file
@@ -102,15 +103,15 @@ This error occurs when trying to use the `overlay` storage Driver but overlay is
 
 ```
 level=error msg="'overlay' not found as a supported filesystem on this host.
-Please ensure kernel is new enough and has overlay support loaded." 
+Please ensure kernel is new enough and has overlay support loaded."
 level=fatal msg="Error starting daemon: error initializing graphdriver: driver not supported"
 ```
 
 This error occurs when using CentOS or RedHat which default to the `devicemapper` storage driver:
 
 ```
-level=error msg="There are no more loopback devices available." 
-level=fatal msg="Error starting daemon: error initializing graphdriver: loopback mounting failed" 
+level=error msg="There are no more loopback devices available."
+level=fatal msg="Error starting daemon: error initializing graphdriver: loopback mounting failed"
 Cannot connect to the Docker daemon. Is 'docker -d' running on this host?
 ```
 

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ type Archive struct {
 type Docker struct {
 	Storage  string   `json:"storage_driver"`
 	Registry string   `json:"registry"`
+	Mirror   string   `json:"mirror"`
 	Insecure bool     `json:"insecure"`
 	Username string   `json:"username"`
 	Password string   `json:"password"`
@@ -81,6 +82,9 @@ func main() {
 		}
 		if vargs.Insecure && len(vargs.Registry) != 0 {
 			args = append(args, "--insecure-registry", vargs.Registry)
+		}
+		if len(vargs.Mirror) != 0 {
+			args = append(args, "--registry-mirror", vargs.Mirror)
 		}
 
 		for _, value := range vargs.Dns {


### PR DESCRIPTION
It is now possibile to optionally specify a mirror registry instead of pulling images directly from the central Hub.