### PR TITLE
Docker graph caching

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -73,10 +73,36 @@ publish:
     build_args:
       - HTTP_PROXY=http://yourproxy.com
 ```
- 
-## Layer Caching
 
-The Drone build environment is, by default, ephemeral meaning that you layers are not saved between builds. The below example combines Drone's caching feature and Docker's `save` and `load` capabilities to cache and restore image layers between builds:
+## Caching
+
+The Drone build environment is, by default, ephemeral meaning that you layers are not saved between builds. There are two methods for caching layers.
+
+### Graph directory caching
+
+This is the preferred method when using the `overlay` storage driver. Just use Drone's caching feature to backup and restore the directory `/drone/docker`, as shown in the following example:
+
+```yaml
+publish:
+  docker:
+    username: kevinbacon
+    password: pa55word
+    email: kevin.bacon@mail.com
+    repo: foo/bar
+    tag:
+      - latest
+      - "1.0.1"
+
+cache:
+  mount:
+    - /drone/docker
+```
+
+NOTE: This probably won't work correctly with the `btrfs` driver, and it will be very inefficient with the `devicemapper` driver. Please make sure to use the `overlay` storage driver with this method.
+
+### Layer Caching
+
+The below example combines Drone's caching feature and Docker's `save` and `load` capabilities to cache and restore image layers between builds:
 
 ```yaml
 publish:

--- a/DOCS.md
+++ b/DOCS.md
@@ -76,7 +76,7 @@ publish:
 
 ## Caching
 
-The Drone build environment is, by default, ephemeral meaning that you layers are not saved between builds. There are two methods for caching layers.
+The Drone build environment is, by default, ephemeral meaning that you layers are not saved between builds. There are two methods for caching your layers.
 
 ### Graph directory caching
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -84,7 +84,7 @@ The Drone build environment is, by default, ephemeral meaning that you layers ar
 
 ### Graph directory caching
 
-This is the preferred method when using the `overlay` storage driver. Just use Drone's caching feature to backup and restore the directory `/drone/docker`, as shown in the following example:
+This is the preferred method when using the `overlay` or `aufs` storage drivers. Just use Drone's caching feature to backup and restore the directory `/drone/docker`, as shown in the following example:
 
 ```yaml
 publish:
@@ -102,7 +102,7 @@ cache:
     - /drone/docker
 ```
 
-NOTE: This probably won't work correctly with the `btrfs` driver, and it will be very inefficient with the `devicemapper` driver. Please make sure to use the `overlay` storage driver with this method.
+NOTE: This probably won't work correctly with the `btrfs` driver, and it will be very inefficient with the `devicemapper` driver. Please make sure to use the `overlay` or `aufs` storage driver with this method.
 
 ### Layer Caching
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -217,6 +218,29 @@ func main() {
 		cmd.Stderr = os.Stderr
 		trace(cmd)
 		err = cmd.Run()
+		if err != nil {
+			os.Exit(1)
+		}
+	}
+
+	// Remove untagged images, if any
+	var outbuf bytes.Buffer
+	cmd = exec.Command("sh", "-c", "docker images | grep '^<none>' | awk '{print $3}'")
+	cmd.Stdout = &outbuf
+	cmd.Stderr = os.Stderr
+	trace(cmd)
+	err = cmd.Run()
+	if err != nil {
+		os.Exit(1)
+	}
+
+	if outbuf.Len() > 0 {
+		images := strings.Split(strings.TrimSpace(outbuf.String()), "\n")
+		cmd = exec.Command("docker", append([]string{"rmi"}, images...)...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		trace(cmd)
+		err := cmd.Run()
 		if err != nil {
 			os.Exit(1)
 		}

--- a/main.go
+++ b/main.go
@@ -87,7 +87,7 @@ func main() {
 	}
 
 	go func() {
-		args := []string{"-d"}
+		args := []string{"-d", "-g", "/drone/docker"}
 
 		if len(vargs.Storage) != 0 {
 			args = append(args, "-s", vargs.Storage)

--- a/main.go
+++ b/main.go
@@ -225,7 +225,7 @@ func main() {
 
 	// Remove untagged images, if any
 	var outbuf bytes.Buffer
-	cmd = exec.Command("sh", "-c", "docker images | grep '^<none>' | awk '{print $3}'")
+	cmd = exec.Command("docker", "images", "-q", "-f", "dangling=true")
 	cmd.Stdout = &outbuf
 	cmd.Stderr = os.Stderr
 	trace(cmd)


### PR DESCRIPTION
This allows caching the whole Docker graph with the cache plugin. Caching is efficient with the overlay storage driver at least. Works much better (also faster) than the existing save/load approach for me. 

The drawback with this approach: old image layers are preserved in the graph directory belonging to the repository. This is why I added code which removes untagged images after the image has been pushed. This makes sure the cache doesn't grow over time. (We could add a configuration option for this, as it is only needed for this kind of caching.)

This caching method probably shouldn't be used with other storage drivers. I only tried `overlay` (good) and `devicemapper` (totally inefficient). Not quite sure if it works with `aufs` (probably only workable if host system also uses aufs). Anyone able to try?