### PR TITLE
Change deprecated argument -d -> daemon

### DIFF
--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func main() {
 	}
 
 	go func() {
-		args := []string{"-d"}
+		args := []string{"daemon"}
 
 		if len(vargs.Storage) != 0 {
 			args = append(args, "-s", vargs.Storage)


### PR DESCRIPTION
Running `docker -d` is deprecated since [1].

[1] https://docs.docker.com/engine/misc/deprecated/#old-command-line-options