### PR TITLE
Add an option to pull images before builds

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -20,6 +20,9 @@ The following parameters are used to configure this plugin:
     * `destination` - absolute / relative destination path
     * `tag` - cherry-pick tags to save (optional)
 * `load` - restore image layers from the specified tar file
+* `pull_before` - pull an image before building
+    * `repo` - repository of the image to pull
+    * `tag` - tag of the image to pull
 * `build_args` - [build arguments](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables-build-arg) to pass to `docker build`
 
 The following is a sample Docker configuration in your .drone.yml file:
@@ -109,6 +112,30 @@ docker/*
 ```
 
 In some cases caching will greatly improve build performance, however, the tradeoff is that caching Docker image layers may consume very large amounts of disk space.
+
+## Pulling Images
+
+You can optionally pull an image before a build with `pull_before`:
+
+```yaml
+publish:
+  docker:
+    username: kevinbacon
+    password: pa55word
+    email: kevin.bacon@mail.com
+    repo: foo/bar
+    tag:
+      - latest
+      - "1.0.1"
+    pull_before:
+      repo: foo/bar
+      tag: latest
+```
+
+Layers from the pulled image can then be used during the build, effectively acting as a cache.
+
+If an earlier version of the image being built is pulled, it can improve build times, but will cause more network traffic.
+For larger images with short build times, this may end up being slower.
 
 ## Troubleshooting
 


### PR DESCRIPTION
As an alternative to caching images on Drone workers, this adds the option to pull an image from a registry before building. If you pull an earlier version of the image you're building, it can act as a remote cache to avoid relying on Drone's local caching.