### PR TITLE
upgraded docker version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #
 #     docker build --rm=true -t plugins/drone-docker .
 
-FROM rancher/docker:1.9.1
+FROM rancher/docker:v1.10.2
 
 ADD drone-docker /go/bin/
 VOLUME /var/lib/docker


### PR DESCRIPTION
@tboerger @bradrydzewski 
The goal of this PR is to update the base image docker version from `1.9.1` to `1.10.2`. Motivation for this comes from consistently seeing the following error in drone builds:

```no-highlight
time="2016-03-08T20:46:42.180274293Z" level=warning msg="signal: killed" 
time="2016-03-08T20:46:42.226610787Z" level=warning msg="failed to cleanup ipc mounts:\nfailed to umount /var/lib/docker/containers/516bb2880e7b115e3957cdde1eef7f1075691527685c831dfb848b705e726c5d/shm: invalid argument\nfailed to umount /var/lib/docker/containers/516bb2880e7b115e3957cdde1eef7f1075691527685c831dfb848b705e726c5d/mqueue: invalid argument" 
[8] System error: mkdir /sys/fs/docker-daemon: read-only file system
[info] build failed (exit code 1)
```

A documented issue similar to the one above can be seen [here](https://github.com/drone/drone/issues/1352). It seems to happen on GKE machines including those running CoreOS, which is my particular use-case. Improvements in Docker 1.10.* seem to fix these issues. 

The simplest solution with the current `drone-docker` plugin is to rerun the builds until they pass. Until some recent PR's such as [this](https://github.com/drone/drone-exec/pull/20) pertaining to the ability to whitelist plugins that should be run as privileged containers are merged, I propose we update the base image for this plugin. 

If the core contributors for this don't wish to update the latest image with the more recent version of Docker I propose that they at least have a tagged image in Docker hub with the updated version for those wishing to use it.