### PR TITLE
Add an option to pull images before builds

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -20,6 +20,7 @@ The following parameters are used to configure this plugin:
     * `destination` - absolute / relative destination path
     * `tag` - cherry-pick tags to save (optional)
 * `load` - restore image layers from the specified tar file
+* `pull_before` - image to pull before building
 * `build_args` - [build arguments](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables-build-arg) to pass to `docker build`
 
 The following is a sample Docker configuration in your .drone.yml file:
@@ -135,6 +136,28 @@ docker/*
 ```
 
 In some cases caching will greatly improve build performance, however, the tradeoff is that caching Docker image layers may consume very large amounts of disk space.
+
+## Pulling Images
+
+You can optionally pull an image before a build with `pull_before`:
+
+```yaml
+publish:
+  docker:
+    username: kevinbacon
+    password: pa55word
+    email: kevin.bacon@mail.com
+    repo: foo/bar
+    tag:
+      - latest
+      - "1.0.1"
+    pull_before: "foo/bar:latest"
+```
+
+Layers from the pulled image can then be used during the build, effectively acting as a cache.
+
+If an earlier version of the image being built is pulled, it can improve build times, but will cause more network traffic.
+For larger images with short build times, this may end up being slower.
 
 ## Troubleshooting
 

--- a/main.go
+++ b/main.go
@@ -21,24 +21,25 @@ type Save struct {
 }
 
 type Docker struct {
-	Storage   string   `json:"storage_driver"`
-	Registry  string   `json:"registry"`
-	Mirror    string   `json:"mirror"`
-	Insecure  bool     `json:"insecure"`
-	Username  string   `json:"username"`
-	Password  string   `json:"password"`
-	Email     string   `json:"email"`
-	Auth      string   `json:"auth"`
-	Repo      string   `json:"repo"`
-	ForceTag  bool     `json:"force_tag"`
-	Tag       StrSlice `json:"tag"`
-	File      string   `json:"file"`
-	Context   string   `json:"context"`
-	Bip       string   `json:"bip"`
-	Dns       []string `json:"dns"`
-	Load      string   `json:"load"`
-	Save      Save     `json:"save"`
-	BuildArgs []string `json:"build_args"`
+	Storage    string   `json:"storage_driver"`
+	Registry   string   `json:"registry"`
+	Mirror     string   `json:"mirror"`
+	Insecure   bool     `json:"insecure"`
+	Username   string   `json:"username"`
+	Password   string   `json:"password"`
+	Email      string   `json:"email"`
+	Auth       string   `json:"auth"`
+	Repo       string   `json:"repo"`
+	ForceTag   bool     `json:"force_tag"`
+	Tag        StrSlice `json:"tag"`
+	File       string   `json:"file"`
+	Context    string   `json:"context"`
+	Bip        string   `json:"bip"`
+	Dns        []string `json:"dns"`
+	Load       string   `json:"load"`
+	Save       Save     `json:"save"`
+	PullBefore string   `json:"pull_before"`
+	BuildArgs  []string `json:"build_args"`
 }
 
 var (
@@ -163,6 +164,18 @@ func main() {
 	cmd.Stderr = os.Stderr
 	trace(cmd)
 	cmd.Run()
+
+	// Pull an image before building
+	if len(vargs.PullBefore) != 0 {
+		cmd := exec.Command("/usr/bin/docker", "pull", vargs.PullBefore)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		trace(cmd)
+		err := cmd.Run()
+		if err != nil {
+			os.Exit(1)
+		}
+	}
 
 	// Restore from tarred image repository
 	if len(vargs.Load) != 0 {


### PR DESCRIPTION
As an alternative to caching images on Drone workers, this adds the option to pull an image from a registry before building. If you pull an earlier version of the image you're building, it can act as a remote cache to avoid relying on Drone's local caching.

#46 but with the right base branch.