### PR TITLE
drone-git -> drone-docker in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# drone-git
+# drone-docker
 
 Drone plugin can be used to build and publish Docker images to a container registry. For the usage information and a listing of the available options please take a look at [the docs](DOCS.md).
 


### PR DESCRIPTION
Assume this was likely a copy and paste error as this isn't docker-git.