### PR TITLE
Support for more complex programmatic tags

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -83,6 +83,18 @@ cache:
     - /drone/docker
 ```
 
+## Complex tags
+
+If you need more detail in your tags then Drone provides by standard, create a .droneTags.yml file in the root of the project with a simple list of tags you would like applied.  This list can be generated programmatically as a build task.
+
+`.droneTags.yml`
+```yaml
+tags:
+  - latest
+  - build_1
+  - owner_repo_feature-branch_1.0.2_1_as3e9214
+```
+
 ## Troubleshooting
 
 For detailed output you can set the `DOCKER_LAUNCH_DEBUG` environment variable in your plugin configuration. This starts Docker with verbose logging enabled.


### PR DESCRIPTION
We would like to use a tagging scheme based on the version of our nodejs applications defined in in the project package.json file. There doesn't seem to be way to inject this into Drone at build time. So as a build task, we are create a simple yaml file with a list of tags (`.droneTags.yml`) in the root of the project and override the passed in Tags with the contents. 

We created this nodejs utility to geneate tags for us https://www.npmjs.com/package/buildgoggles

If you want to name the yaml file something else I'm more then happy to change.

`.droneTags.yml`
```yaml
tags:
  - latest
  - v1.0.2-1
  - owner_project_feature-some-long-name_1.0.2_1_ae82ac97
```