### PR TITLE
fixed appending registry before the repo

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -61,7 +61,7 @@ func (p Plugin) Exec() error {
 	// this code attempts to normalize the repository name by appending the fully
 	// qualified registry name if otherwise omitted.
 	if p.Login.Registry != defaultRegistry &&
-		strings.HasPrefix(p.Build.Repo, defaultRegistry) {
+		!strings.HasPrefix(p.Build.Repo, p.Login.Registry) {
 		p.Build.Repo = p.Login.Registry + "/" + p.Build.Repo
 	}
 


### PR DESCRIPTION
It should prepend `p.Login.Registry` only if login.registry is not equal to defaultRegistry and build.repo is not started with login.registry.
