### PR TITLE
Add ability to accept multiple push registries

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -149,6 +150,11 @@ func main() {
 			Usage:  "docker email",
 			EnvVar: "DOCKER_EMAIL,PLUGIN_EMAIL",
 		},
+		cli.StringFlag{
+			Name:   "push.registries",
+			Usage:  "push registries",
+			EnvVar: "PLUGIN_PUSH_REGISTRIES",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -191,5 +197,32 @@ func run(c *cli.Context) error {
 		},
 	}
 
+	if r, err := parsePushRegistries(c.String("push.registries"), plugin.Login.Registry); err == nil {
+		plugin.PushRegistries = r
+	} else {
+		return err
+	}
+
 	return plugin.Exec()
+}
+
+func parsePushRegistries(raw, defaultRegistry string) ([]Login, error) {
+	if raw == "" {
+		return nil, nil
+	}
+
+	var out []Login
+
+	if err := json.Unmarshal([]byte(raw), &out); err != nil {
+		return nil, fmt.Errorf("Failed to parse push registries: %s", err.Error())
+	}
+
+	// Default to the main registry set, in case only a repo is provided
+	for i := range out {
+		if out[i].Registry == "" {
+			out[i].Registry = defaultRegistry
+		}
+	}
+
+	return out, nil
 }


### PR DESCRIPTION
Like so:
```yaml
[...]
push_registries:
  - repo: something/else
  - registry: gcr.io/
    repo: a/b
  - registry: gcr.io/
    repo: a/c
  - registry: https://docker.lumerico.com/
    repo: super/secret
    username: roadhog
    password: timetogowholehog
```

Notes:
- If a registry is not specified, it inherits from the main config.
- Attempts to login to each registry before building. If the registry matches the main config and either the username is blank or the same as the main username, it skips login.
- Attempts to push each tag to each repo specified.

Thanks in advance for the review!