### PR TITLE
allowing docker to use cached base image in build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,3 @@ _testmain.go
 
 coverage.out
 drone-docker
-
-# IDE/Editor related files
-**.swp

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ _testmain.go
 
 coverage.out
 drone-docker
+
+# IDE/Editor related files
+**.swp

--- a/main.go
+++ b/main.go
@@ -118,6 +118,11 @@ func main() {
 			Usage:  "squash the layers at build time",
 			EnvVar: "PLUGIN_SQUASH",
 		},
+		cli.BoolTFlag{
+			Name:   "cache",
+			Usage:  "don't attempt to re-build layers of the image that already exist",
+			EnvVar: "PLUGIN_USE_CACHE",
+		},
 		cli.BoolFlag{
 			Name:   "compress",
 			Usage:  "compress the build context using gzip",
@@ -172,6 +177,7 @@ func run(c *cli.Context) error {
 			Tags:       c.StringSlice("tags"),
 			Args:       c.StringSlice("args"),
 			Squash:     c.Bool("squash"),
+			Cache:       c.Bool("cache"),
 			Compress:   c.Bool("compress"),
 			Repo:       c.String("repo"),
 		},

--- a/main.go
+++ b/main.go
@@ -119,9 +119,9 @@ func main() {
 			EnvVar: "PLUGIN_SQUASH",
 		},
 		cli.BoolTFlag{
-			Name:   "cache",
-			Usage:  "don't attempt to re-build layers of the image that already exist",
-			EnvVar: "PLUGIN_USE_CACHE",
+			Name:   "pull-image",
+			Usage:  "force pull base image at build time",
+			EnvVar: "PLUGIN_PULL_IMAGE",
 		},
 		cli.BoolFlag{
 			Name:   "compress",
@@ -177,7 +177,7 @@ func run(c *cli.Context) error {
 			Tags:       c.StringSlice("tags"),
 			Args:       c.StringSlice("args"),
 			Squash:     c.Bool("squash"),
-			Cache:       c.Bool("cache"),
+			Pull:       c.BoolT("pull-image"),
 			Compress:   c.Bool("compress"),
 			Repo:       c.String("repo"),
 		},

--- a/plugin.go
+++ b/plugin.go
@@ -47,7 +47,7 @@ type (
 		Tags       []string // Docker build tags
 		Args       []string // Docker build args
 		Squash     bool     // Docker build squash
-		Cache      bool     // Docker build without pulling
+		Pull       bool     // Docker build pull
 		Compress   bool     // Docker build compress
 		Repo       string   // Docker build repository
 	}
@@ -186,7 +186,7 @@ func commandInfo() *exec.Cmd {
 
 // helper function to create the docker build command.
 func commandBuild(build Build) *exec.Cmd {
-	args := []string {
+	args := []string{
 		"build",
 		"--rm=true",
 		"-f", build.Dockerfile,
@@ -200,11 +200,9 @@ func commandBuild(build Build) *exec.Cmd {
 	if build.Compress {
 		args = append(args, "--compress")
 	}
-    if build.Cache {
-        args = append(args, "--pull=false")
-    } else {
-        args = append(args, "--pull=true")
-    }
+	if build.Pull {
+		args = append(args, "--pull=true")
+	}
 	for _, arg := range build.Args {
 		args = append(args, "--build-arg", arg)
 	}

--- a/plugin.go
+++ b/plugin.go
@@ -47,6 +47,7 @@ type (
 		Tags       []string // Docker build tags
 		Args       []string // Docker build args
 		Squash     bool     // Docker build squash
+		Cache      bool     // Docker build without pulling
 		Compress   bool     // Docker build compress
 		Repo       string   // Docker build repository
 	}
@@ -187,7 +188,6 @@ func commandInfo() *exec.Cmd {
 func commandBuild(build Build) *exec.Cmd {
 	args := []string {
 		"build",
-		"--pull=true",
 		"--rm=true",
 		"-f", build.Dockerfile,
 		"-t", build.Name,
@@ -200,6 +200,11 @@ func commandBuild(build Build) *exec.Cmd {
 	if build.Compress {
 		args = append(args, "--compress")
 	}
+    if build.Cache {
+        args = append(args, "--pull=false")
+    } else {
+        args = append(args, "--pull=true")
+    }
 	for _, arg := range build.Args {
 		args = append(args, "--build-arg", arg)
 	}


### PR DESCRIPTION
This fixes the last comment in issue https://github.com/drone-plugins/drone-docker/issues/34 - and adds a flag to allow _not_ pulling the base image down on every build.

I'm not 100% sure that the name I've given to the option is good, but I couldn't get the EnvVar options to work with a bool flag that was true-by-default correctly :/. This being my first go code ever, I'm happy to take any suggestions/help regarding this!

example usage:
```
  publish:
    image: plugins/drone-docker:<NEW_VERSION>
    repo: <MY_REPO>
    use_cache: true
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock
```

Needs to be run as trusted for the volume obviously!