### PR TITLE
Change env precedence

### DIFF
--- a/main.go
+++ b/main.go
@@ -137,22 +137,22 @@ func main() {
 			Name:   "docker.registry",
 			Usage:  "docker registry",
 			Value:  defaultRegistry,
-			EnvVar: "DOCKER_REGISTRY,PLUGIN_REGISTRY",
+			EnvVar: "PLUGIN_REGISTRY,DOCKER_REGISTRY",
 		},
 		cli.StringFlag{
 			Name:   "docker.username",
 			Usage:  "docker username",
-			EnvVar: "DOCKER_USERNAME,PLUGIN_USERNAME",
+			EnvVar: "PLUGIN_USERNAME,DOCKER_USERNAME",
 		},
 		cli.StringFlag{
 			Name:   "docker.password",
 			Usage:  "docker password",
-			EnvVar: "DOCKER_PASSWORD,PLUGIN_PASSWORD",
+			EnvVar: "PLUGIN_PASSWORD,DOCKER_PASSWORD",
 		},
 		cli.StringFlag{
 			Name:   "docker.email",
 			Usage:  "docker email",
-			EnvVar: "DOCKER_EMAIL,PLUGIN_EMAIL",
+			EnvVar: "PLUGIN_EMAIL,DOCKER_EMAIL",
 		},
 	}
 


### PR DESCRIPTION
When using the config values `registry`, `username`, `password`, and `email`, if the corresponding `DOCKER_` env var is set, the explicit values are ignored. This is due to the `urfave/cli` package taking the first available env var.

This PR changes the order so that explicit configuration is favored over environmental. If the config order is intentional, please feel free to close this PR!

Thanks in advance!