### PR TITLE
Remove temp tag from build and prune afterwards

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -112,7 +112,7 @@ func (p Plugin) Exec() error {
 	var cmds []*exec.Cmd
 	cmds = append(cmds, commandVersion())      // docker version
 	cmds = append(cmds, commandInfo())         // docker info
-	cmds = append(cmds, commandDockerPrune())  // cleanup docker
+
 	cmds = append(cmds, commandBuild(p.Build)) // docker build
 
 	for _, tag := range p.Build.Tags {
@@ -122,6 +122,9 @@ func (p Plugin) Exec() error {
 			cmds = append(cmds, commandPush(p.Build, tag)) // docker push
 		}
 	}
+
+	cmds = append(cmds, commandRmi(p.Build.Name)) // docker rmi
+	cmds = append(cmds, commandPrune())           // docker system prune -f
 
 	// execute all commands in batch mode.
 	for _, cmd := range cmds {
@@ -291,8 +294,12 @@ func commandDaemon(daemon Daemon) *exec.Cmd {
 	return exec.Command(dockerdExe, args...)
 }
 
-func commandDockerPrune() *exec.Cmd {
+func commandPrune() *exec.Cmd {
 	return exec.Command(dockerExe, "system", "prune", "-f")
+}
+
+func commandRmi(tag string) *exec.Cmd {
+	return exec.Command(dockerExe, "rmi", tag)
 }
 
 // trace writes each command to stdout with the command wrapped in an xml


### PR DESCRIPTION
This PR will untag the "temp" tag (`p.Build.Name`) from the image so that `docker system prune` can properly clean it up.  Currently `docker system prune` does nothing.

However, this PR will not work until Docker 17.04 is released as there is a bug prior to that where `docker system prune` does not properly clean dangling images.  https://github.com/docker/docker/issues/32006

So I just wanted to get this code/issue in the open.  We can either merge knowing it won't really do anything until 17.04 is released and the plugin uses it ... or wait until 17.04 is released and the plugin is using it before merging.