### PR TITLE
integrate changes from drone-gcr/pull/20

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -21,3 +21,14 @@ pipeline:
     when:
       branch: master
       event: push
+
+
+  publish:
+    image: plugins/gcr
+    repo: plugins/gcr
+    dockerfile: Dockerfile_gcr
+    tags: [ "latest", "17", "17.05" ]
+    secrets: [ docker_username, docker_password ]
+    when:
+      branch: master
+      event: push

--- a/Dockerfile_gcr
+++ b/Dockerfile_gcr
@@ -1,0 +1,11 @@
+FROM plugins/docker:17.05
+
+ENV HOME /
+
+RUN \
+       apk add -Uuv --no-cache ca-certificates jq \
+    && rm -rf /var/cache/apk/*
+
+ADD bin/wrap-drone-docker.sh /bin/wrap-drone-docker.sh
+
+ENTRYPOINT ["/bin/wrap-drone-docker.sh"]

--- a/bin/wrap-drone-docker.sh
+++ b/bin/wrap-drone-docker.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -eu
+
+# attempt to detect JSON v. Baste64 encoding
+if (echo "${TOKEN}" | jq -e '.project_id'); then
+    DOCKER_PASSWORD="${TOKEN}"
+else
+    DOCKER_PASSWORD="$(echo "${TOKEN}" | base64 -d)"
+fi
+
+DOCKER_REGISTRY="${PLUGIN_REGISTRY:-gcr.io}"
+DOCKER_USERNAME="_json_key"
+
+# set variables for using Docker with GCR
+export DOCKER_REGISTRY DOCKER_USERNAME DOCKER_PASSWORD
+
+# invoke the docker plugin
+exec /bin/drone-docker "$@"

--- a/plugin.go
+++ b/plugin.go
@@ -79,6 +79,11 @@ func (p Plugin) Exec() error {
 		}()
 	}
 
+	// Concat the Registry URL and the Repository name if necessary
+	if strings.Count(p.Build.Repo, "/") == 1 {
+		p.Build.Repo = fmt.Sprintf("%s/%s", p.Login.Registry, p.Build.Repo)
+	}
+
 	// poll the docker daemon until it is started. This ensures the daemon is
 	// ready to accept connections before we proceed.
 	for i := 0; i < 15; i++ {


### PR DESCRIPTION
This is based on work here: https://github.com/drone-plugins/drone-gcr/pull/20

I made a couple changes to the wrapper script, most are pretty inconsequential but changing the way that jq is called to "detect" json in the token value was important: the previous version would leak the token into build logs regardless of whether debug was turned on.

I had to make a change to `plugin.go` to concatenate the docker registry and repo together. I assumed that if you did a `docker login` to `gcr.io` it would pick that registry for a `docker push` but that was not the case.

Also I'm not exactly sure how this is going to work w.r.t. tags. `Dockerfile_gcr` wants to pull `FROM plugins/docker:17.05` but that depends on the previous step running, and updating the image under that tag.
