### PR TITLE
aarch64(arm64) Dockerfile added.

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,0 +1,7 @@
+FROM ergu/docker-dind-arm64:17.05.0-ce-dind
+
+RUN ln -s /usr/bin/dockerd /usr/local/bin/dockerd
+RUN ln -s /usr/bin/docker /usr/local/bin/docker
+
+ADD drone-docker /bin/
+ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh", "/bin/drone-docker"]


### PR DESCRIPTION
To test this plugin inside Drone within arm64 architecture one can use the deployed plugin at https://hub.docker.com/r/ergu/drone-docker-arm64/ and check the related Docker repos at https://hub.docker.com/u/ergu/.