### PR TITLE
Configurable pruning

### DIFF
--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -102,6 +102,11 @@ func main() {
 			Usage:  "don't start the docker daemon",
 			EnvVar: "PLUGIN_DAEMON_OFF",
 		},
+		cli.BoolFlag{
+			Name:   "daemon.disable-system-prune",
+			Usage:  "don't run post-build docker system prune",
+			EnvVar: "PLUGIN_DISABLE_SYSTEM_PRUNE",
+		},
 		cli.StringFlag{
 			Name:   "dockerfile",
 			Usage:  "build dockerfile",
@@ -214,6 +219,7 @@ func run(c *cli.Context) error {
 			StoragePath:   c.String("daemon.storage-path"),
 			Insecure:      c.Bool("daemon.insecure"),
 			Disabled:      c.Bool("daemon.off"),
+			DisablePrune:  c.Bool("daemon.disable-system-prune"),
 			IPv6:          c.Bool("daemon.ipv6"),
 			Debug:         c.Bool("daemon.debug"),
 			Bip:           c.String("daemon.bip"),

--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -107,6 +107,11 @@ func main() {
 			Usage:  "don't run post-build docker system prune",
 			EnvVar: "PLUGIN_DISABLE_SYSTEM_PRUNE",
 		},
+		cli.BoolFlag{
+			Name:   "daemon.disable-image-removal",
+			Usage:  "don't run post-build docker rmi",
+			EnvVar: "PLUGIN_DISABLE_IMAGE_REMOVAL",
+		},
 		cli.StringFlag{
 			Name:   "dockerfile",
 			Usage:  "build dockerfile",
@@ -220,6 +225,7 @@ func run(c *cli.Context) error {
 			Insecure:      c.Bool("daemon.insecure"),
 			Disabled:      c.Bool("daemon.off"),
 			DisablePrune:  c.Bool("daemon.disable-system-prune"),
+			DisableRMI:    c.Bool("daemon.disable-image-removal"),
 			IPv6:          c.Bool("daemon.ipv6"),
 			Debug:         c.Bool("daemon.debug"),
 			Bip:           c.String("daemon.bip"),

--- a/docker.go
+++ b/docker.go
@@ -19,6 +19,7 @@ type (
 		StoragePath   string   // Docker daemon storage path
 		Disabled      bool     // Docker daemon is disabled (already running)
 		DisablePrune  bool     // Docker daemon won't run post-build prune
+		DisableRMI    bool     // Docker daemon won't run post-build rmi
 		Debug         bool     // Docker daemon started in debug mode
 		Bip           string   // Docker daemon network bridge IP address
 		DNS           []string // Docker daemon dns server
@@ -123,7 +124,9 @@ func (p Plugin) Exec() error {
 		}
 	}
 
-	cmds = append(cmds, commandRmi(p.Build.Name)) // docker rmi
+	if !p.Daemon.DisableRMI {
+		cmds = append(cmds, commandRmi(p.Build.Name)) // docker rmi
+	}
 	if !p.Daemon.DisablePrune {
 		cmds = append(cmds, commandPrune()) // docker system prune -f
 	}

--- a/docker.go
+++ b/docker.go
@@ -17,7 +17,7 @@ type (
 		Insecure      bool     // Docker daemon enable insecure registries
 		StorageDriver string   // Docker daemon storage driver
 		StoragePath   string   // Docker daemon storage path
-		Disabled      bool     // DOcker daemon is disabled (already running)
+		Disabled      bool     // Docker daemon is disabled (already running)
 		DisablePrune  bool     // Docker daemon won't run post-build prune
 		Debug         bool     // Docker daemon started in debug mode
 		Bip           string   // Docker daemon network bridge IP address

--- a/docker.go
+++ b/docker.go
@@ -18,6 +18,7 @@ type (
 		StorageDriver string   // Docker daemon storage driver
 		StoragePath   string   // Docker daemon storage path
 		Disabled      bool     // DOcker daemon is disabled (already running)
+		DisablePrune  bool     // Docker daemon won't run post-build prune
 		Debug         bool     // Docker daemon started in debug mode
 		Bip           string   // Docker daemon network bridge IP address
 		DNS           []string // Docker daemon dns server
@@ -123,7 +124,9 @@ func (p Plugin) Exec() error {
 	}
 
 	cmds = append(cmds, commandRmi(p.Build.Name)) // docker rmi
-	cmds = append(cmds, commandPrune())           // docker system prune -f
+	if !p.Daemon.DisablePrune {
+		cmds = append(cmds, commandPrune()) // docker system prune -f
+	}
 
 	// execute all commands in batch mode.
 	for _, cmd := range cmds {


### PR DESCRIPTION
As per Gitter [convo](https://gitter.im/drone/drone?at=59a434ff210ac26920cdc5e9), this PR adds flags for disabling post-build rmi and pruning. We'll definitely want to do image removal out-of-band, but may also want to handle pruning on our own. This is a Kubernetes setup with a separate DinD container co-located in the pod that contains the agent, which means we're still DinD (but not within Drone).

cc @foklepoint