### PR TITLE
Change possible password fields for GCR

### DIFF
--- a/cmd/drone-docker-gcr/main.go
+++ b/cmd/drone-docker-gcr/main.go
@@ -19,7 +19,7 @@ func main() {
 			"PLUGIN_JSON_KEY",
 			"GCR_JSON_KEY",
 			"GOOGLE_CREDENTIALS",
-			"GOOGLE_APPLICATION_CREDENTIALS",
+			"TOKEN",
 		)
 	)
 


### PR DESCRIPTION
GOOGLE_APPLICATION_CREDENTIALS "should point to a file that defines the credentials", and should not be the contents of the credentials to follow Google's convention.

See https://developers.google.com/identity/protocols/application-default-credentials#howtheywork.

I replaced it with `TOKEN` to match the parameter of the previous GCR plugin worked, which may help with migrations.

