### PR TITLE
ignore empty tags to make plugin more stable

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -116,6 +116,10 @@ func (p Plugin) Exec() error {
 	cmds = append(cmds, commandBuild(p.Build)) // docker build
 
 	for _, tag := range p.Build.Tags {
+		if tag == "" { // ignore empty tags
+			continue
+		}
+		
 		cmds = append(cmds, commandTag(p.Build, tag)) // docker tag
 
 		if p.Dryrun == false {


### PR DESCRIPTION
There is a common use for this plugin to publish ```latest``` as well as ```${DRONETAG}```

```
    tags:
      - latest
      - ${DRONE_TAG}
```
However, sometimes code change without adding a tag will publish fail since there is no tags, but we need to publish to the ```latest``` in this case.


