### PR TITLE
Use stable v17.12 Docker dind image.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,7 @@ pipeline:
   publish:
     image: plugins/docker
     repo: plugins/docker
-    tags: [ "latest", "17", "17.10", "17.12" ]
+    tags: [ "latest", "17", "17.12" ]
     secrets: [ docker_username, docker_password ]
     dockerfile: docker/Dockerfile
     when:
@@ -23,7 +23,7 @@ pipeline:
   publish_heroku:
     image: plugins/docker
     repo: plugins/heroku
-    tags: [ "latest", "17", "17.10", "17.12" ]
+    tags: [ "latest", "17", "17.12" ]
     secrets: [ docker_username, docker_password ]
     dockerfile: docker/heroku/Dockerfile
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,7 @@ pipeline:
   publish:
     image: plugins/docker
     repo: plugins/docker
-    tags: [ "latest", "17", "17.10" ]
+    tags: [ "latest", "17", "17.10", "17.12" ]
     secrets: [ docker_username, docker_password ]
     dockerfile: docker/Dockerfile
     when:
@@ -23,7 +23,7 @@ pipeline:
   publish_heroku:
     image: plugins/docker
     repo: plugins/heroku
-    tags: [ "latest", "17", "17.10" ]
+    tags: [ "latest", "17", "17.10", "17.12" ]
     secrets: [ docker_username, docker_password ]
     dockerfile: docker/heroku/Dockerfile
     when:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 # docker build --rm -f docker/Dockerfile -t plugins/docker .
 
-FROM docker:17.10.0-ce-dind
+FROM docker:17.12.0-ce-dind
 
 ADD release/linux/amd64/drone-docker /bin/
 ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh", "/bin/drone-docker"]


### PR DESCRIPTION
Uses the latest stable dind by default, which at the minute has better default ca certificates.