### PR TITLE
Allow build for a specific target

### DIFF
--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -149,7 +149,7 @@ func main() {
 		cli.StringFlag{
 			Name:   "target",
 			Usage:  "build target",
-			EnvVar: "PLUGIN_BUILD_TARGET",
+			EnvVar: "PLUGIN_TARGET",
 		},
 		cli.BoolFlag{
 			Name:   "squash",

--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -146,6 +146,11 @@ func main() {
 			Usage:  "build args",
 			EnvVar: "PLUGIN_BUILD_ARGS_FROM_ENV",
 		},
+		cli.StringFlag{
+			Name:   "target",
+			Usage:  "build target",
+			EnvVar: "PLUGIN_BUILD_TARGET",
+		},
 		cli.BoolFlag{
 			Name:   "squash",
 			Usage:  "squash the layers at build time",
@@ -227,6 +232,7 @@ func run(c *cli.Context) error {
 			Tags:        c.StringSlice("tags"),
 			Args:        c.StringSlice("args"),
 			ArgsEnv:     c.StringSlice("args-from-env"),
+			Target:      c.String("target"),
 			Squash:      c.Bool("squash"),
 			Pull:        c.BoolT("pull-image"),
 			Compress:    c.Bool("compress"),

--- a/docker.go
+++ b/docker.go
@@ -44,6 +44,7 @@ type (
 		Tags        []string // Docker build tags
 		Args        []string // Docker build args
 		ArgsEnv     []string // Docker build args from env
+		Target      string   // Docker build target
 		Squash      bool     // Docker build squash
 		Pull        bool     // Docker build pull
 		Compress    bool     // Docker build compress
@@ -203,6 +204,9 @@ func commandBuild(build Build) *exec.Cmd {
 	}
 	for _, arg := range build.Args {
 		args = append(args, "--build-arg", arg)
+	}
+	if build.Target != "" {
+		args = append(args, "--target", build.Target)
 	}
 
 	labelSchema := []string{


### PR DESCRIPTION
In order to use the multi-stage build we should specify the `--target` flag (official [docs](https://docs.docker.com/engine/reference/commandline/build/#specifying-target-build-stage-target)), this PR allow us to indicate the layer to build, eg:
```diff
 pipeline:
   publish-dev:
     image: plugins/docker
     repo: mavimo/test
     tags: [ "latest", "prod" ]
+    target: production
     when:
       branch: master
       event: push

   publish-dev:
     image: plugins/docker
     repo: mavimo/test
     tags: [ "latest", "dev" ]
+    target: development
     when:
       branch: develop
       event: push
```
`Dockerfile`:
```
FROM php:7.1.13-fpm as production

COPY config/php.ini /usr/local/etc/php/php.ini

WORKDIR /srv

CMD ["php-fpm"]

FROM production as development

RUN apt-get update && apt-get install -y wget zip unzip git
```

NB: porting from https://github.com/drone-plugins/drone-docker/pull/136 and https://github.com/drone-plugins/drone-docker/pull/161