### PR TITLE
Fix ECR registry string trimming

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,8 @@ pipeline:
     commands:
       - go get -u github.com/golang/dep/cmd/dep
       - dep ensure
-      - go test ./...
+      - go vet ./...
+      - go test -cover ./...
       - sh .drone.sh
 
   publish:

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,7 @@ pipeline:
     commands:
       - go get -u github.com/golang/dep/cmd/dep
       - dep ensure
+      - go test ./...
       - sh .drone.sh
 
   publish:

--- a/cmd/drone-docker-ecr/main.go
+++ b/cmd/drone-docker-ecr/main.go
@@ -55,7 +55,7 @@ func main() {
 	}
 
 	if create {
-		err = ensureRepoExists(svc, strings.SplitN(repo, "/", 2)[1])
+		err = ensureRepoExists(svc, getRepoName(repo))
 		if err != nil {
 			log.Fatal(fmt.Sprintf("error creating ECR repo: %v", err))
 		}
@@ -73,6 +73,10 @@ func main() {
 	if err = cmd.Run(); err != nil {
 		os.Exit(1)
 	}
+}
+
+func getRepoName(repo string) string {
+	return strings.SplitN(repo, "/", 2)[1]
 }
 
 func ensureRepoExists(svc *ecr.ECR, name string) (err error) {

--- a/cmd/drone-docker-ecr/main.go
+++ b/cmd/drone-docker-ecr/main.go
@@ -55,9 +55,9 @@ func main() {
 	}
 
 	if create {
-		err = ensureRepoExists(svc, strings.TrimPrefix(repo, registry))
+		err = ensureRepoExists(svc, strings.SplitN(repo, "/", 2)[1])
 		if err != nil {
-			os.Exit(1)
+			log.Fatal(fmt.Sprintf("error creating ECR repo: %v", err))
 		}
 	}
 

--- a/cmd/drone-docker-ecr/main.go
+++ b/cmd/drone-docker-ecr/main.go
@@ -55,7 +55,7 @@ func main() {
 	}
 
 	if create {
-		err = ensureRepoExists(svc, getRepoName(repo))
+		err = ensureRepoExists(svc, trimHostname(repo, registry))
 		if err != nil {
 			log.Fatal(fmt.Sprintf("error creating ECR repo: %v", err))
 		}
@@ -75,8 +75,10 @@ func main() {
 	}
 }
 
-func getRepoName(repo string) string {
-	return strings.SplitN(repo, "/", 2)[1]
+func trimHostname(repo, registry string) string {
+	repo = strings.TrimPrefix(repo, registry)
+	repo = strings.TrimLeft(repo, "/")
+	return repo
 }
 
 func ensureRepoExists(svc *ecr.ECR, name string) (err error) {

--- a/cmd/drone-docker-ecr/main_test.go
+++ b/cmd/drone-docker-ecr/main_test.go
@@ -1,0 +1,19 @@
+package main
+
+import "testing"
+
+func TestGetRepoName(t *testing.T) {
+	// map full repo path to expected repo name
+	repos := map[string]string{
+		"000000000000.dkr.ecr.us-east-1.amazonaws.com/repo":                     "repo",
+		"000000000000.dkr.ecr.us-east-1.amazonaws.com/namespace/repo":           "namespace/repo",
+		"000000000000.dkr.ecr.us-east-1.amazonaws.com/namespace/namespace/repo": "namespace/namespace/repo",
+	}
+
+	for repo, name := range repos {
+		splitName := getRepoName(repo)
+		if splitName != name {
+			t.Errorf("%s is not equal to %s.", splitName, name)
+		}
+	}
+}

--- a/cmd/drone-docker-ecr/main_test.go
+++ b/cmd/drone-docker-ecr/main_test.go
@@ -2,16 +2,17 @@ package main
 
 import "testing"
 
-func TestGetRepoName(t *testing.T) {
+func TestTrimHostname(t *testing.T) {
+	registry := "000000000000.dkr.ecr.us-east-1.amazonaws.com"
 	// map full repo path to expected repo name
 	repos := map[string]string{
-		"000000000000.dkr.ecr.us-east-1.amazonaws.com/repo":                     "repo",
-		"000000000000.dkr.ecr.us-east-1.amazonaws.com/namespace/repo":           "namespace/repo",
-		"000000000000.dkr.ecr.us-east-1.amazonaws.com/namespace/namespace/repo": "namespace/namespace/repo",
+		registry + "/repo":                     "repo",
+		registry + "/namespace/repo":           "namespace/repo",
+		registry + "/namespace/namespace/repo": "namespace/namespace/repo",
 	}
 
 	for repo, name := range repos {
-		splitName := getRepoName(repo)
+		splitName := trimHostname(repo, registry)
 		if splitName != name {
 			t.Errorf("%s is not equal to %s.", splitName, name)
 		}


### PR DESCRIPTION
This addresses an issue when using `plugins/ecr` with `create_repository: true`. The current `TrimPrefix()` call tries to create a repo with a name like `/namespace/repo` which fails AWS API's [repositoryName constraints](https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_CreateRepository.html#ECR-CreateRepository-request-repositoryName).

I believe this might address some of the issues @mhumeSF mentioned in [here](https://discourse.drone.io/t/plugins-ecr-does-not-auto-create-repo-in-ecr/1099).