### PR TITLE
Create image tags at build time

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -124,10 +124,8 @@ func (p Plugin) Exec() error {
 
 	cmds = append(cmds, commandBuild(p.Build)) // docker build
 
-	for _, tag := range p.Build.Tags {
-		cmds = append(cmds, commandTag(p.Build, tag)) // docker tag
-
-		if p.Dryrun == false {
+	if p.Dryrun == false {
+		for _, tag := range p.Build.Tags {
 			cmds = append(cmds, commandPush(p.Build, tag)) // docker push
 		}
 	}
@@ -205,10 +203,14 @@ func commandBuild(build Build) *exec.Cmd {
 		"build",
 		"--rm=true",
 		"-f", build.Dockerfile,
-		"-t", build.Name,
+	}
+
+	for _, tag := range build.Tags {
+		args = append(args, "-t", tag)
 	}
 
 	args = append(args, build.Context)
+
 	if build.Squash {
 		args = append(args, "--squash")
 	}
@@ -299,17 +301,6 @@ func hasProxyBuildArg(build *Build, key string) bool {
 	}
 
 	return false
-}
-
-// helper function to create the docker tag command.
-func commandTag(build Build, tag string) *exec.Cmd {
-	var (
-		source = build.Name
-		target = fmt.Sprintf("%s:%s", build.Repo, tag)
-	)
-	return exec.Command(
-		dockerExe, "tag", source, target,
-	)
 }
 
 // helper function to create the docker push command.


### PR DESCRIPTION
Instead of doing a `docker tag` at the end of the build, we can do it directly in the `docker build` command (since version 1.10)