### PR TITLE
Support reading build-args from a file

### DIFF
--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -140,6 +140,7 @@ func main() {
 			Name:   "args",
 			Usage:  "build args",
 			EnvVar: "PLUGIN_BUILD_ARGS",
+			FilePath: ".build-args",
 		},
 		cli.StringSliceFlag{
 			Name:   "args-from-env",


### PR DESCRIPTION
Similar to .tags, this allows to set .build-args in a file, allowing to
split configuration (e.g. which image version is used as a base image)
from the Dockerfile.


