### PR TITLE
Add support for non label-schema labels

### DIFF
--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -172,6 +172,11 @@ func main() {
 			EnvVar: "PLUGIN_REPO",
 		},
 		cli.StringSliceFlag{
+			Name:   "Labels",
+			Usage:  "labels",
+			EnvVar: "PLUGIN_LABELS",
+		},
+		cli.StringSliceFlag{
 			Name:   "label-schema",
 			Usage:  "label-schema labels",
 			EnvVar: "PLUGIN_LABEL_SCHEMA",
@@ -242,6 +247,7 @@ func run(c *cli.Context) error {
 			Pull:        c.BoolT("pull-image"),
 			Compress:    c.Bool("compress"),
 			Repo:        c.String("repo"),
+			Labels:      c.StringSlice("labels"),
 			LabelSchema: c.StringSlice("label-schema"),
 			NoCache:     c.Bool("no-cache"),
 		},

--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -172,9 +172,9 @@ func main() {
 			EnvVar: "PLUGIN_REPO",
 		},
 		cli.StringSliceFlag{
-			Name:   "Labels",
-			Usage:  "labels",
-			EnvVar: "PLUGIN_LABELS",
+			Name:   "custom-labels",
+			Usage:  "additional k=v labels",
+			EnvVar: "PLUGIN_CUSTOM_LABELS",
 		},
 		cli.StringSliceFlag{
 			Name:   "label-schema",
@@ -247,7 +247,7 @@ func run(c *cli.Context) error {
 			Pull:        c.BoolT("pull-image"),
 			Compress:    c.Bool("compress"),
 			Repo:        c.String("repo"),
-			Labels:      c.StringSlice("labels"),
+			Labels:      c.StringSlice("custom-labels"),
 			LabelSchema: c.StringSlice("label-schema"),
 			NoCache:     c.Bool("no-cache"),
 		},

--- a/docker.go
+++ b/docker.go
@@ -215,7 +215,7 @@ func commandBuild(build Build) *exec.Cmd {
 	}
 
 	labelSchema := []string{
-		"version=1.0",
+		"schema-version=1.0",
 		fmt.Sprintf("build-date=%s", time.Now().Format(time.RFC3339)),
 		fmt.Sprintf("vcs-ref=%s", build.Name),
 		fmt.Sprintf("vcs-url=%s", build.Remote),

--- a/docker.go
+++ b/docker.go
@@ -49,7 +49,8 @@ type (
 		Pull        bool     // Docker build pull
 		Compress    bool     // Docker build compress
 		Repo        string   // Docker build repository
-		LabelSchema []string // Label schema map
+		LabelSchema []string // label-schema Label map
+		Labels      []string // Label map
 		NoCache     bool     // Docker build no-cache
 	}
 
@@ -214,6 +215,7 @@ func commandBuild(build Build) *exec.Cmd {
 	}
 
 	labelSchema := []string{
+		"version=1.0",
 		fmt.Sprintf("build-date=%s", time.Now().Format(time.RFC3339)),
 		fmt.Sprintf("vcs-ref=%s", build.Name),
 		fmt.Sprintf("vcs-url=%s", build.Remote),
@@ -225,6 +227,12 @@ func commandBuild(build Build) *exec.Cmd {
 
 	for _, label := range labelSchema {
 		args = append(args, "--label", fmt.Sprintf("org.label-schema.%s", label))
+	}
+
+	if len(build.Labels) > 0 {
+		for _, label := range build.Labels {
+			args = append(args, "--label", label)
+		}
 	}
 
 	return exec.Command(dockerExe, args...)


### PR DESCRIPTION
After the label-schema.org label support was added, this PR now adds the strongly suggested `org.label-schema.version` label by default and adds support for 'regular' labels similar to the tags and build args.
This incidently solves both comments in the original PR ;) 

For backwards compatibility I've kept the `label-schema` option.

# References
#134 
#135  