### PR TITLE
Use the user specified Registry

### DIFF
--- a/cmd/drone-docker-ecr/main.go
+++ b/cmd/drone-docker-ecr/main.go
@@ -19,11 +19,12 @@ const defaultRegion = "us-east-1"
 
 func main() {
 	var (
-		repo   = getenv("PLUGIN_REPO")
-		region = getenv("PLUGIN_REGION", "ECR_REGION", "AWS_REGION")
-		key    = getenv("PLUGIN_ACCESS_KEY", "ECR_ACCESS_KEY", "AWS_ACCESS_KEY_ID")
-		secret = getenv("PLUGIN_SECRET_KEY", "ECR_SECRET_KEY", "AWS_SECRET_ACCESS_KEY")
-		create = parseBoolOrDefault(false, getenv("PLUGIN_CREATE_REPOSITORY", "ECR_CREATE_REPOSITORY"))
+		repo     = getenv("PLUGIN_REPO")
+		registry = getenv("PLUGIN_REGISTRY")
+		region   = getenv("PLUGIN_REGION", "ECR_REGION", "AWS_REGION")
+		key      = getenv("PLUGIN_ACCESS_KEY", "ECR_ACCESS_KEY", "AWS_ACCESS_KEY_ID")
+		secret   = getenv("PLUGIN_SECRET_KEY", "ECR_SECRET_KEY", "AWS_SECRET_ACCESS_KEY")
+		create   = parseBoolOrDefault(false, getenv("PLUGIN_CREATE_REPOSITORY", "ECR_CREATE_REPOSITORY"))
 	)
 
 	// set the region
@@ -45,7 +46,12 @@ func main() {
 	}
 
 	svc := ecr.New(sess)
-	username, password, registry, err := getAuthInfo(svc)
+	username, password, defaultRegistry, err := getAuthInfo(svc)
+
+	if registry == "" {
+		registry = defaultRegistry
+	}
+
 	if err != nil {
 		log.Fatal(fmt.Sprintf("error getting ECR auth: %v", err))
 	}


### PR DESCRIPTION
Hey! This PR ensures that the ecr executable honors the user specified registry.

The current behavior uses the registry returned by the ECR authentication token regardless of what the user specifies. While this registry is a good default, the token also authenticates the client to push to any other repository that has an AWS trust relationship established with the current account. We should let the user specify one such registry.