### PR TITLE
Update readme about plugins/docker has special privileges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Drone plugin to build and publish Docker images to a container registry.
 
+### Special privilieges
+
+This docker image is specified in Drone to run with Privilieged mode. If you fork this repository to run it on your own, you need to specify your docker image in the `DRONE_ESCALATE`, as the container needs to run in privilieged mode, otherwise it will not work! https://github.com/drone/drone/blob/master/cmd/drone-server/server.go
+
 ## Build
 
 Build the binary with the following commands:


### PR DESCRIPTION
I didn't know about this and I could not understand why I couldn't get other docker images to work the same way as plugins/docker worked. Wasted around 2 hours trying all kinds of stuff. Not mad, just want to spare other peoples time as I think it is quite an important undocumented feature, something quite unusual for Drone for what my impression has been.

As you can see it is not mentioned a single time in the docs, and being "container-native" you could assume that people would want to test building Docker images https://github.com/drone/docs/search?q=DRONE_ESCALATE&type=Code