### PR TITLE
Allow to cache the intermediate steps of a multi-stage build

### DIFF
--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -248,6 +248,11 @@ func main() {
 			Usage:  "additional host:IP mapping",
 			EnvVar: "PLUGIN_ADD_HOST",
 		},
+		cli.BoolFlag{
+			Name:   "stream",
+			Usage:  "stream the build context",
+			EnvVar: "PLUGIN_STREAM",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -287,6 +292,7 @@ func run(c *cli.Context) error {
 			NoCache:       c.Bool("no-cache"),
 			AddHost:       c.StringSlice("add-host"),
 			Quiet:         c.Bool("quiet"),
+			Stream:        c.Bool("stream"),
 		},
 		Daemon: docker.Daemon{
 			Registry:      c.String("docker.registry"),

--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -253,6 +253,11 @@ func main() {
 			Usage:  "stream the build context",
 			EnvVar: "PLUGIN_STREAM",
 		},
+		cli.BoolFlag{
+			Name:   "push-target",
+			Usage:  "push the target image along the final image",
+			EnvVar: "PLUGIN_PUSH_TARGET",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -293,6 +298,7 @@ func run(c *cli.Context) error {
 			AddHost:       c.StringSlice("add-host"),
 			Quiet:         c.Bool("quiet"),
 			Stream:        c.Bool("stream"),
+			PushTarget:    c.Bool("push-target"),
 		},
 		Daemon: docker.Daemon{
 			Registry:      c.String("docker.registry"),

--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -258,6 +258,11 @@ func main() {
 			Usage:  "push the target image along the final image",
 			EnvVar: "PLUGIN_PUSH_TARGET",
 		},
+		cli.StringFlag{
+			Name:   "target-tag",
+			Usage:  "target build tag",
+			EnvVar: "PLUGIN_TARGET_TAG",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -299,6 +304,7 @@ func run(c *cli.Context) error {
 			Quiet:         c.Bool("quiet"),
 			Stream:        c.Bool("stream"),
 			PushTarget:    c.Bool("push-target"),
+			TargetTag:     c.String("target-tag"),
 		},
 		Daemon: docker.Daemon{
 			Registry:      c.String("docker.registry"),

--- a/docker.go
+++ b/docker.go
@@ -61,6 +61,7 @@ type (
 		Quiet       bool     // Docker build quiet
 		Stream      bool     // Docker build stream
 		PushTarget  bool     // build final image and push built target
+		TargetTag   string   // build target tag
 	}
 
 	// Plugin defines the Docker plugin parameters.
@@ -162,15 +163,21 @@ func (p Plugin) Exec() error {
 
 	// push the target if requested
 	if p.Build.PushTarget {
-		target := p.Build.Target
-		cmds = append(cmds, commandTag(p.Build, target)) // docker tag
+		var targetTag string
+		// use a custom target tag if set, else use the default target name
+		if p.Build.TargetTag != "" {
+			targetTag = p.Build.TargetTag
+		} else {
+			targetTag = p.Build.Target
+		}
+		cmds = append(cmds, commandTag(p.Build, targetTag)) // docker tag
 
 		// clear the target so a normal build can be done
 		p.Build.Target = ""
 		cmds = append(cmds, commandBuild(p.Build)) // docker build
 
 		if p.Dryrun == false {
-			cmds = append(cmds, commandPush(p.Build, target)) // docker push
+			cmds = append(cmds, commandPush(p.Build, targetTag)) // docker push
 		}
 	}
 

--- a/docker.go
+++ b/docker.go
@@ -59,6 +59,7 @@ type (
 		NoCache     bool     // Docker build no-cache
 		AddHost     []string // Docker build add-host
 		Quiet       bool     // Docker build quiet
+		Stream      bool     // Docker build stream
 	}
 
 	// Plugin defines the Docker plugin parameters.
@@ -132,6 +133,11 @@ func (p Plugin) Exec() error {
 	if p.Build.Squash && !p.Daemon.Experimental {
 		fmt.Println("Squash build flag is only available when Docker deamon is started with experimental flag. Ignoring...")
 		p.Build.Squash = false
+	}
+
+	if p.Build.Stream && !p.Daemon.Experimental {
+		fmt.Println("Stream build flag is only available when Docker deamon is started with experimental flag. Ignoring...")
+		p.Build.Stream = false
 	}
 
 	// add proxy build args
@@ -236,6 +242,9 @@ func commandBuild(build Build) *exec.Cmd {
 	args = append(args, build.Context)
 	if build.Squash {
 		args = append(args, "--squash")
+	}
+	if build.Stream {
+		args = append(args, "--stream")
 	}
 	if build.Compress {
 		args = append(args, "--compress")


### PR DESCRIPTION
This PR allows to cache the target image of a multi-stage build so it can be pulled later as a cache and speed up builds. Since `docker build` has to be run twice with the same context, i added support to  `stream` the context and save time by don't sending it twice to the daemon.

The patch is simple enough and i have been using for two months without a problem with multiple deployments and allowed me to simplify my drone config files. This approach would be more simpler than the alternative of declaring multiple steps on the `.drone.yml` file.

```yaml
steps:
  - name: build
    image: codestation/drone-docker
    settings:
      repo: registry.example.com/someimage
      registry: registry.example.com
      tags: latest
      stream: true
      target: builder
      push_target: true
      experimental: true
      cache_from:
        - registry.example.com/someimage:builder
        - registry.example.com/someimage:latest
      username:
        from_secret: docker_username
      password:
        from_secret: docker_password
```

The build will also work without `stream` (that option requires `experimental`) but it will be a little slower because it has to send the context twice.