### PR TITLE
append tags with autotag instead of replacing

### DIFF
--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -280,10 +280,10 @@ func run(c *cli.Context) error {
 			c.String("commit.ref"),
 			c.String("repo.branch"),
 		) {
-			plugin.Build.Tags = docker.DefaultTagSuffix(
+			plugin.Build.Tags = append(plugin.Build.Tags, docker.DefaultTagSuffix(
 				c.String("commit.ref"),
 				c.String("tags.suffix"),
-			)
+			)...)
 		} else {
 			logrus.Printf("skipping automated docker build for %s", c.String("commit.ref"))
 			return nil


### PR DESCRIPTION
As in #201 mentioned it can be helpful to allow static tags in addition to the auto tags. I. e.: having a production tag that always matches the last tag.

closes #201


