### PR TITLE
Remove secrets from build arg trace

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -20,7 +20,7 @@ func (p Plugin) startDaemon() {
 		cmd.Stderr = ioutil.Discard
 	}
 	go func() {
-		trace(cmd)
+		trace(os.Stdout, cmd)
 		cmd.Run()
 	}()
 }

--- a/docker_test.go
+++ b/docker_test.go
@@ -1,1 +1,27 @@
 package docker
+
+import (
+	"bytes"
+	"os/exec"
+	"testing"
+)
+
+func Test_trace(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmd    *exec.Cmd
+		want string
+	}{
+		{"no args", exec.Command("docker", "system", "prune", "-f"), "+ docker system prune -f\n"},
+		{"with args", exec.Command("docker", "build", "--build-arg", "SECRET=e7fa7552-e08a-4479-9959-7169df4ce686"), "+ docker build --build-arg SECRET={redacted}\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := &bytes.Buffer{}
+			trace(out, tt.cmd)
+			if gotOut := out.String(); gotOut != tt.want {
+				t.Errorf("trace() = %v, want %v", gotOut, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
--build-args often contain secrets which drone this plugin prints.

This change does two things:
- makes trace() testable
- adds tests for trace
- removes the values from any --build-arg