### PR TITLE
Revert "Reapply append tags with autotag instead of replacing"

### DIFF
--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -280,10 +280,10 @@ func run(c *cli.Context) error {
 			c.String("commit.ref"),
 			c.String("repo.branch"),
 		) {
-			plugin.Build.Tags = append(plugin.Build.Tags, docker.DefaultTagSuffix(
+			plugin.Build.Tags = docker.DefaultTagSuffix(
 				c.String("commit.ref"),
 				c.String("tags.suffix"),
-			)...)
+			)
 		} else {
 			logrus.Printf("skipping automated docker build for %s", c.String("commit.ref"))
 			return nil


### PR DESCRIPTION
Reverts drone-plugins/drone-docker#245. @foosinn if you still would like to see that feature please make sure that auto tagging won't get broken as with this patch it always applies `latest`.