### PR TITLE
Add DinD proxy support

### DIFF
--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 
-	"github.com/drone-plugins/drone-docker"
+	docker "github.com/drone-plugins/drone-docker"
 )
 
 var (
@@ -92,6 +92,21 @@ func main() {
 			Name:   "daemon.ipv6",
 			Usage:  "docker daemon IPv6 networking",
 			EnvVar: "PLUGIN_IPV6",
+		},
+		cli.StringSliceFlag{
+			Name:   "daemon.http_proxy",
+			Usage:  "docker daemon http proxy server",
+			EnvVar: "PLUGIN_HTTP_PROXY",
+		},
+		cli.StringSliceFlag{
+			Name:   "daemon.https_proxy",
+			Usage:  "docker daemon https proxy server",
+			EnvVar: "PLUGIN_HTTPS_PROXY",
+		},
+		cli.StringSliceFlag{
+			Name:   "daemon.noproxy",
+			Usage:  "docker daemon noproxy settings",
+			EnvVar: "PLUGIN_NOPROXY",
 		},
 		cli.BoolFlag{
 			Name:   "daemon.experimental",
@@ -265,6 +280,7 @@ func run(c *cli.Context) error {
 			AddHost:     c.StringSlice("add-host"),
 		},
 		Daemon: docker.Daemon{
+			//Name:   "daemon.http_proxy",
 			Registry:      c.String("docker.registry"),
 			Mirror:        c.String("daemon.mirror"),
 			StorageDriver: c.String("daemon.storage-driver"),
@@ -277,6 +293,9 @@ func run(c *cli.Context) error {
 			DNS:           c.StringSlice("daemon.dns"),
 			DNSSearch:     c.StringSlice("daemon.dns-search"),
 			MTU:           c.String("daemon.mtu"),
+			HTTPProxy:     c.String("docker.http_proxy"),
+			HTTPSProxy:    c.String("docker.https_proxy"),
+			NoProxy:       c.String("docker.noproxy"),
 			Experimental:  c.Bool("daemon.experimental"),
 		},
 	}

--- a/daemon.go
+++ b/daemon.go
@@ -5,10 +5,32 @@ package docker
 import (
 	"io/ioutil"
 	"os"
+	"text/template"
 )
 
-const dockerExe = "/usr/local/bin/docker"
-const dockerdExe = "/usr/local/bin/dockerd"
+const (
+	daemonConfigTemplate = `{
+		{{ if .HTTPProxy || .HTTPSProxy || .NoProxy }}
+		"proxies": {
+			"default": {
+				{{ if .HTTPProxy }}
+				"httpProxy": "{{.HTTPProxy}},
+				{{ endif }}
+				{{ if .HTTPSProxy }}
+				"httpsProxy": "{{.HTTPSProxy}},
+				{{ endif }}
+				{{ if .NoProxy }}
+				"noProxy": "{{.NoProxy}}
+				{{ endif }}
+			}
+		}
+		{{ endif }}
+	}`
+
+	dockerConfigDir = "/root/.docker/"
+	dockerExe       = "/usr/local/bin/docker"
+	dockerdExe      = "/usr/local/bin/dockerd"
+)
 
 func (p Plugin) startDaemon() {
 	cmd := commandDaemon(p.Daemon)
@@ -23,4 +45,25 @@ func (p Plugin) startDaemon() {
 		trace(cmd)
 		cmd.Run()
 	}()
+}
+
+// Creates the file needed for dind going through a proxy
+func (p Plugin) setProxyConfig() {
+	dConfTempl, err := template.New("dConfTempl").Parse(daemonConfigTemplate)
+	if err != nil {
+		panic("internal error (daemon config template invalid)")
+	}
+	if _, err := os.Stat(dockerConfigDir); err != nil {
+		os.Mkdir(dockerConfigDir, 0755)
+	}
+	f, err := os.Create(dockerConfigDir + "config.json")
+	if err != nil {
+		panic(dockerConfigDir + "config.json")
+	}
+	defer f.Close()
+	err = dConfTempl.Execute(f, p.Daemon)
+	if err != nil {
+		panic("Could not template daemon config")
+	}
+	f.Sync()
 }

--- a/docker.go
+++ b/docker.go
@@ -24,6 +24,9 @@ type (
 		MTU           string   // Docker daemon mtu setting
 		IPv6          bool     // Docker daemon IPv6 networking
 		Experimental  bool     // Docker daemon enable experimental mode
+		HTTPProxy     string   // Docker daemon http proxy
+		HTTPSProxy    string   // Docker daemon https proxy
+		NoProxy       string   // Docker daemon noproxy settings
 	}
 
 	// Login defines Docker login parameters.
@@ -69,6 +72,7 @@ type (
 func (p Plugin) Exec() error {
 	// start the Docker daemon server
 	if !p.Daemon.Disabled {
+		p.setProxyConfig()
 		p.startDaemon()
 	}
 


### PR DESCRIPTION
When running DroneCI behind a corporate Proxy, it might be necessary to pass proxy settings to the docker daemon.