### PR TITLE
Update Docker to 19.03.8

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -330,7 +330,10 @@ func commandPush(build Build, tag string) *exec.Cmd {
 
 // helper function to create the docker daemon command.
 func commandDaemon(daemon Daemon) *exec.Cmd {
-	args := []string{"--data-root", daemon.StoragePath}
+	args := []string{
+		"--data-root", daemon.StoragePath,
+		"--host=unix:///var/run/docker.sock",
+	}
 
 	if daemon.StorageDriver != "" {
 		args = append(args, "-s", daemon.StorageDriver)

--- a/docker/docker/Dockerfile.linux.amd64
+++ b/docker/docker/Dockerfile.linux.amd64
@@ -1,4 +1,6 @@
 FROM docker:19.03.5-dind
 
+ENV DOCKER_HOST=unix:///var/run/docker.sock
+
 ADD release/linux/amd64/drone-docker /bin/
 ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh", "/bin/drone-docker"]

--- a/docker/docker/Dockerfile.linux.amd64
+++ b/docker/docker/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM docker:18.09.0-dind
+FROM docker:19.03.5-dind
 
 ADD release/linux/amd64/drone-docker /bin/
 ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh", "/bin/drone-docker"]

--- a/docker/docker/Dockerfile.linux.amd64
+++ b/docker/docker/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM docker:19.03.5-dind
+FROM docker:19.03.8-dind
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 

--- a/docker/docker/Dockerfile.linux.arm
+++ b/docker/docker/Dockerfile.linux.arm
@@ -1,4 +1,4 @@
-FROM arm32v6/docker:19.03.5-dind
+FROM arm32v6/docker:19.03.8-dind
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 

--- a/docker/docker/Dockerfile.linux.arm
+++ b/docker/docker/Dockerfile.linux.arm
@@ -1,4 +1,4 @@
-FROM arm32v6/docker:18.09.0-dind
+FROM arm32v6/docker:19.03.5-dind
 
 ADD release/linux/arm/drone-docker /bin/
 ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh", "/bin/drone-docker"]

--- a/docker/docker/Dockerfile.linux.arm
+++ b/docker/docker/Dockerfile.linux.arm
@@ -1,4 +1,6 @@
 FROM arm32v6/docker:19.03.5-dind
 
+ENV DOCKER_HOST=unix:///var/run/docker.sock
+
 ADD release/linux/arm/drone-docker /bin/
 ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh", "/bin/drone-docker"]

--- a/docker/docker/Dockerfile.linux.arm64
+++ b/docker/docker/Dockerfile.linux.arm64
@@ -1,4 +1,4 @@
-FROM arm64v8/docker:18.09.0-dind
+FROM arm64v8/docker:19.03.5-dind
 
 ADD release/linux/arm64/drone-docker /bin/
 ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh", "/bin/drone-docker"]

--- a/docker/docker/Dockerfile.linux.arm64
+++ b/docker/docker/Dockerfile.linux.arm64
@@ -1,4 +1,6 @@
 FROM arm64v8/docker:19.03.5-dind
 
+ENV DOCKER_HOST=unix:///var/run/docker.sock
+
 ADD release/linux/arm64/drone-docker /bin/
 ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh", "/bin/drone-docker"]

--- a/docker/docker/Dockerfile.linux.arm64
+++ b/docker/docker/Dockerfile.linux.arm64
@@ -1,4 +1,4 @@
-FROM arm64v8/docker:19.03.5-dind
+FROM arm64v8/docker:19.03.8-dind
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 


### PR DESCRIPTION
As commented in #244 few changes as been made to docker dind. 

Per default, Docker daemon now listen on a UNIX AND TCP with TLS sockets, the client also tries to connect on the openned TCP socket (default behavior)

Since we don't need to expose Docker API with a TCP socket, I just started the daemon with UNIX socket and made the client trying to connect using UNIX socket like before.

I double checked docker entrypoint flow for this PR https://github.com/docker-library/docker/blob/master/19.03/dind/dockerd-entrypoint.sh#L129#L132 and since we start using `drone-docker` binary, almost all of this entrypoint code is useless

The only doubt I have is, I needed to run my test image `tuxity/drone-docker` with `privileged: true` in order to correctly start the docker daemon. I guess it's because it's not an official image