### PR TITLE
Added docker configuration

### DIFF
--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -208,6 +208,11 @@ func main() {
 			Usage:  "docker email",
 			EnvVar: "PLUGIN_EMAIL,DOCKER_EMAIL",
 		},
+		cli.StringFlag{
+			Name:   "docker.authconfig",
+			Usage:  "docker json authconfig content",
+			EnvVar: "PLUGIN_AUTHCONFIG,DOCKER_AUTHCONFIG",
+		},
 		cli.BoolTFlag{
 			Name:   "docker.purge",
 			Usage:  "docker should cleanup images",
@@ -240,10 +245,11 @@ func run(c *cli.Context) error {
 		Dryrun:  c.Bool("dry-run"),
 		Cleanup: c.BoolT("docker.purge"),
 		Login: docker.Login{
-			Registry: c.String("docker.registry"),
-			Username: c.String("docker.username"),
-			Password: c.String("docker.password"),
-			Email:    c.String("docker.email"),
+			Registry:   c.String("docker.registry"),
+			Username:   c.String("docker.username"),
+			Password:   c.String("docker.password"),
+			Email:      c.String("docker.email"),
+			AuthConfig: c.String("docker.authconfig"),
 		},
 		Build: docker.Build{
 			Remote:      c.String("remote.url"),

--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -209,9 +209,9 @@ func main() {
 			EnvVar: "PLUGIN_EMAIL,DOCKER_EMAIL",
 		},
 		cli.StringFlag{
-			Name:   "docker.docker_config",
+			Name:   "docker.config",
 			Usage:  "docker json dockerconfig content",
-			EnvVar: "PLUGIN_DOCKER_CONFIG,DOCKER_CONFIG",
+			EnvVar: "PLUGIN_CONFIG",
 		},
 		cli.BoolTFlag{
 			Name:   "docker.purge",
@@ -249,7 +249,7 @@ func run(c *cli.Context) error {
 			Username:   c.String("docker.username"),
 			Password:   c.String("docker.password"),
 			Email:      c.String("docker.email"),
-			DockerConfig: c.String("docker.docker_config"),
+			DockerConfig: c.String("docker.config"),
 		},
 		Build: docker.Build{
 			Remote:      c.String("remote.url"),

--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -209,9 +209,9 @@ func main() {
 			EnvVar: "PLUGIN_EMAIL,DOCKER_EMAIL",
 		},
 		cli.StringFlag{
-			Name:   "docker.authconfig",
-			Usage:  "docker json authconfig content",
-			EnvVar: "PLUGIN_AUTHCONFIG,DOCKER_AUTHCONFIG",
+			Name:   "docker.docker_config",
+			Usage:  "docker json dockerconfig content",
+			EnvVar: "PLUGIN_DOCKER_CONFIG,DOCKER_CONFIG",
 		},
 		cli.BoolTFlag{
 			Name:   "docker.purge",
@@ -249,7 +249,7 @@ func run(c *cli.Context) error {
 			Username:   c.String("docker.username"),
 			Password:   c.String("docker.password"),
 			Email:      c.String("docker.email"),
-			AuthConfig: c.String("docker.authconfig"),
+			DockerConfig: c.String("docker.docker_config"),
 		},
 		Build: docker.Build{
 			Remote:      c.String("remote.url"),

--- a/daemon.go
+++ b/daemon.go
@@ -9,6 +9,7 @@ import (
 
 const dockerExe = "/usr/local/bin/docker"
 const dockerdExe = "/usr/local/bin/dockerd"
+const dockerrootconfdir = "/root/.docker/"
 
 func (p Plugin) startDaemon() {
 	cmd := commandDaemon(p.Daemon)

--- a/daemon_win.go
+++ b/daemon_win.go
@@ -4,6 +4,7 @@ package docker
 
 const dockerExe = "C:\\bin\\docker.exe"
 const dockerdExe = ""
+const dockerrootconfdir = "C:\\ProgramData\\docker\"
 
 func (p Plugin) startDaemon() {
 	// this is a no-op on windows


### PR DESCRIPTION
I've added the possibility to create a docker config for the root user from variable.
In this way using a secret you will be able to add all the authentication parameters for all the registries that you want.

In this example I need to authenticate to
-  registry.redhat.io (as build step)
- quey.io (as Dockerfile FROM as sourcedata)
- docker.io (as Dockerfile FROM as dockerexample)
- selfhosted_registry (as Dockerfile FROM as localdata)

 example:
```yaml
kind: pipeline
name: default
image_pull_secrets:
  - dockerconfig
steps:
  - name: pull ubi7
    image: registry.redhat.io/ubi7/ubi:7.7
    purge: false
    commands:
      - echo $HOSTNAME

  - name: pull ose-ansible
    image: registry.redhat.io/openshift3/ose-ansible:latest
    purge: false
    commands:
      - echo $HOSTNAME

  - name: build and publish on internal registry
    # image: plugins/docker
    # (ATM is in my repo of you want to try this functionality)
    image: docker.io/koma85/plugins-docker 
    privileged: true
    settings:
      dry_run: false
      dockerfile: Dockerfile
      purge: false
      auto_tag: true
      registry: docker.io
      repo: koma85/acontainerthatiwanttobuild
      docker_config:
        from_secret: dockerconfig
```
The variables are:
```
		cli.StringFlag{
			Name:   "docker.docker_config",
			Usage:  "docker json dockerconfig content",
			EnvVar: "PLUGIN_DOCKER_CONFIG,DOCKER_CONFIG",
		},
```