### PR TITLE
Ease work with custom context

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -211,10 +211,12 @@ func commandBuild(build Build) *exec.Cmd {
 	args := []string{
 		"build",
 		"--rm=true",
-		"-f", build.Dockerfile,
-		"-t", build.Name,
 	}
 
+	if build.Dockerfile != "Dockerfile" {
+		args = append(args, "-f", build.Dockerfile)
+	}
+	args = append(args, "-t", build.Name)
 	args = append(args, build.Context)
 	if build.Squash {
 		args = append(args, "--squash")


### PR DESCRIPTION
Currently, there's an issue when you work with custom context:

```yaml
settings:
  repo: repo/app
  context: app/

# $ docker build --rm=true -f Dockerfile -t ... app/
```

It translates to following command, which seeks for `Dockerfile` in root directory instead of context one (which is definitely more common situation) and gives us an error:

```bash
$ docker build --rm=true -f Dockerfile -t aa13f37ccf521ff651bbaa8fce5169a118aa6a89 app/
unable to prepare context: unable to evaluate symlinks in Dockerfile path: lstat /home/agrrh/repos/my-project/Dockerfile: no such file or directory
```

So we are forced to also state custom path also for `dockerfile` to make things happen:

```yaml
settings:
  repo: repo/app
  context: app/
  dockerfile: app/Dockerfile

# works now!
# $ docker build --rm=true -f app/Dockerfile -t ... app/
```

Here I propose to not append dockerfile path to command when dockerfile is default one. It lets custom context to work as expected:

```yaml
settings:
  repo: repo/app
  context: app/

# $ docker build --rm=true -t ... app/
```

Another way to solve the issue is to unconditionally prepend context path: `-f {context}/Dockerfile`.

What do you think?