### PR TITLE
DefaultTags() returns non-semver tags as-is.

### DIFF
--- a/tags.go
+++ b/tags.go
@@ -43,7 +43,7 @@ func DefaultTags(ref string) []string {
 	v := stripTagPrefix(ref)
 	version, err := semver.NewVersion(v)
 	if err != nil {
-		return []string{"latest"}
+		return []string{v}
 	}
 	if version.PreRelease != "" || version.Metadata != "" {
 		return []string{

--- a/tags_test.go
+++ b/tags_test.go
@@ -35,8 +35,11 @@ func TestDefaultTags(t *testing.T) {
 		{"refs/tags/v1.0.0", []string{"1", "1.0", "1.0.0"}},
 		{"refs/tags/v1.0.0-alpha.1", []string{"1.0.0-alpha.1"}},
 
+		// not semver tags as-is
+		{"refs/tags/x1.0.0", []string{"x1.0.0"}},
+		{"refs/tags/local_test", []string{"local_test"}},
+
 		// malformed or errors
-		{"refs/tags/x1.0.0", []string{"latest"}},
 		{"v1.0.0", []string{"latest"}},
 	}
 


### PR DESCRIPTION
The previous behavior of `DefaultTags()` causes problems to us because our staging environment depends on (ie. pulls) the `latest` images so whenever not a semver tag hits the repository, `auto_tag` eventually moves the `latest` tag to another arbitrary image in the repository.

IMHO it would be better to make the build fail or use the provided tag as is.

For further details visit: https://github.com/drone-plugins/drone-docker/issues/237#issuecomment-627393512


