### PR TITLE
compose DRONE_COMMIT_SHA and DRONE_STAGE_NUMBER as docker temporary tag.

### DIFF
--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -238,6 +238,12 @@ func main() {
 			Usage:  "additional host:IP mapping",
 			EnvVar: "PLUGIN_ADD_HOST",
 		},
+		cli.StringFlag{
+			Name:   "stage.number",
+			Usage:  "drone stage number",
+			EnvVar: "DRONE_STAGE_NUMBER",
+			Value:  "0",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -258,7 +264,7 @@ func run(c *cli.Context) error {
 		},
 		Build: docker.Build{
 			Remote:      c.String("remote.url"),
-			Name:        c.String("commit.sha"),
+			Name:        c.String("commit.sha") + "_" + c.String("stage.number"),
 			Dockerfile:  c.String("dockerfile"),
 			Context:     c.String("context"),
 			Tags:        c.StringSlice("tags"),

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,6 @@ github.com/sirupsen/logrus v1.3.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPx
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
-github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.22.2 h1:gsqYFH8bb9ekPA12kRo0hfjngWQjkJPlN9R0N78BoUo=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793 h1:u+LnwYTOOW7Ukr/fppxEb1Nwz0AtPflrblfvUudpo+I=


### PR DESCRIPTION
When we use drone-plugins/drone-docker in a multi-stage drone pipeline for multi-module maven project, the pipeline failed to build container image. After investigating the cause of the failure, we found that the same docker temporary tag was used in every stage for the drone-docker plugin. So, we compose DRONE_COMMIT_SHA and DRONE_STAGE_NUMBER as docker temporary tag to solve this problem.