### PR TITLE
Adding Ignore Checks for prune and rmi

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -135,6 +135,10 @@ func (p Plugin) Exec() error {
 		err := cmd.Run()
 		if err != nil && isCommandPull(cmd.Args) {
 			fmt.Printf("Could not pull cache-from image %s. Ignoring...\n", cmd.Args[2])
+		} else if err != nil && isCommandPrune(cmd.Args) {
+			fmt.Printf("Could not prune system containers. Ignoring...\n")
+		} else if err != nil && isCommandRmi(cmd.Args) {
+			fmt.Printf("Could not remove image %s. Ignoring...\n", cmd.Args[2])
 		} else if err != nil {
 			return err
 		}
@@ -341,8 +345,19 @@ func commandDaemon(daemon Daemon) *exec.Cmd {
 	return exec.Command(dockerdExe, args...)
 }
 
+
+// helper to check if args match "docker prune"
+func isCommandPrune(args []string) bool {
+	return len(args) > 2 && args[1] == "prune"
+}
+
 func commandPrune() *exec.Cmd {
 	return exec.Command(dockerExe, "system", "prune", "-f")
+}
+
+// helper to check if args match "docker rmi"
+func isCommandRmi(args []string) bool {
+	return len(args) > 2 && args[1] == "rmi"
 }
 
 func commandRmi(tag string) *exec.Cmd {


### PR DESCRIPTION
We are trying to utilize image caching from the host machine a bit more and we're using the docker socket volume mount and seeing an issue with the `docker prune` such as the following:

pipeline is here : https://github.com/rancher/rancher/blob/master/.drone.yml#L345-L452
error: https://drone-publish.rancher.io/rancher/rancher/2828/3/4 pertinent parts below.
```
215 | + C:\bin\docker.exe rmi 2cd59a6e1694658e28b85deba6c9440f7496daf0
216 | Untagged: 2cd59a6e1694658e28b85deba6c9440f7496daf0:latest
217 | + C:\bin\docker.exe system prune -f
218 | Error response from daemon: a prune operation is already running
219 | exit status 1
```

This PR adds a similar check as the `isCommandPull` check so that we ignore the error and move on and assume the next job will successfully call `rmi` and `prune`.


