### PR TITLE
changed prune to 3rd arg in check

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -376,7 +376,7 @@ func commandDaemon(daemon Daemon) *exec.Cmd {
 
 // helper to check if args match "docker prune"
 func isCommandPrune(args []string) bool {
-	return len(args) > 2 && args[1] == "prune"
+	return len(args) > 3 && args[2] == "prune"
 }
 
 func commandPrune() *exec.Cmd {


### PR DESCRIPTION
forgot to bump the prune check +1 arg location per this error output

```

+ C:\bin\docker.exe rmi 6a7313a1c02bc1943a80305385b80bf1df1bce88
--
121 | Error: No such image: 6a7313a1c02bc1943a80305385b80bf1df1bce88
122 | Could not remove image 6a7313a1c02bc1943a80305385b80bf1df1bce88. Ignoring...
123 | + C:\bin\docker.exe system prune -f
124 | Error response from daemon: a prune operation is already running
125 | exit status 1

```