### PR TITLE
Add a CLI argument to allow to change local docker tag

### DIFF
--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -238,6 +238,11 @@ func main() {
 			Usage:  "additional host:IP mapping",
 			EnvVar: "PLUGIN_ADD_HOST",
 		},
+		cli.StringSliceFlag{
+			Name:   "local.image.name",
+			Usage:  "local image name",
+			EnvVar: "PLUGIN_LOCAL_IMAGE_NAME,DRONE_COMMIT_SHA",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -258,7 +263,7 @@ func run(c *cli.Context) error {
 		},
 		Build: docker.Build{
 			Remote:      c.String("remote.url"),
-			Name:        c.String("commit.sha"),
+			Name:        c.String("local.image.name"),
 			Dockerfile:  c.String("dockerfile"),
 			Context:     c.String("context"),
 			Tags:        c.StringSlice("tags"),


### PR DESCRIPTION
Hi,

We use the Drone ECR plugin and we ran into concurrency issues when building multiple Docker artifacts on the same build while sharing the docker socket.

What happen is that the drone-docker plugin use the commit sha to tag the image locally and then use this commit sha to push it to ECR. If we build two images with different content in parallel then the tag points to only one artifact.
Here is some log sample

Step 1:
```
Successfully built a9224c5f1d24
Successfully tagged 0515f488ff68847461643ded2956b4589becda15:latest
+ /usr/local/bin/docker tag 0515f488ff68847461643ded2956b4589becda15 0123456789.dkr.ecr.us-east-1.amazonaws.com/company/product-api:stage
+ /usr/local/bin/docker push 0123456789.dkr.ecr.us-east-1.amazonaws.com/company/product-api:stage
The push refers to repository [0123456789.dkr.ecr.us-east-1.amazonaws.com/company/product-api] 
```

Step 2:
```
Successfully built 027cbb85f932
Successfully tagged 0515f488ff68847461643ded2956b4589becda15:latest
+ /usr/local/bin/docker tag 0515f488ff68847461643ded2956b4589becda15 0123456789.dkr.ecr.us-east-1.amazonaws.com/company/product-router:stage
+ /usr/local/bin/docker push 0123456789.dkr.ecr.us-east-1.amazonaws.com/company/product-router:stage
The push refers to repository [0123456789.dkr.ecr.us-east-1.amazonaws.com/company/product-router] 
```

As you can see the two steps share the same local tag which means that under the right circumstances the two repos: 
* 0123456789.dkr.ecr.us-east-1.amazonaws.com/company/product-api
* 0123456789.dkr.ecr.us-east-1.amazonaws.com/company/product-router
Have the same image (same exact digest)

I am proposing to add a new parameter so that each artifact can have it's own local tag.