### PR TITLE
Allow image loading instead of building

### DIFF
--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -238,6 +238,21 @@ func main() {
 			Usage:  "additional host:IP mapping",
 			EnvVar: "PLUGIN_ADD_HOST",
 		},
+		cli.BoolFlag{
+			Name:   "load-image",
+			Usage:  "load image from a file instead of building it",
+			EnvVar: "PLUGIN_LOAD_IMAGE",
+		},
+		cli.StringFlag{
+			Name:   "loaded-image-tag",
+			Usage:  "the tag of the loaded image",
+			EnvVar: "PLUGIN_LOAD_IMAGE_TAG",
+		},
+		cli.StringFlag{
+			Name:   "loaded-image-location",
+			Usage:  "the location of image file",
+			EnvVar: "PLUGIN_LOAD_IMAGE_LOCATION",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -247,7 +262,10 @@ func main() {
 
 func run(c *cli.Context) error {
 	plugin := docker.Plugin{
-		Dryrun:  c.Bool("dry-run"),
+		Dryrun:            c.Bool("dry-run"),
+		Loadimage:         c.Bool("load-image"),
+		Loadedimagetag:    c.String("loaded-image-tag"),
+		Loadedimagelocation: c.String("loaded-image-location"),
 		Cleanup: c.BoolT("docker.purge"),
 		Login: docker.Login{
 			Registry: c.String("docker.registry"),


### PR DESCRIPTION
This is an answer to the following topic: https://discourse.drone.io/t/how-to-push-a-tar-gz-docker-image-on-drone-cloud/7749
Hope that having an ability to easily use Nix with Drone Cloud benefit both communities.

Questions:
- is this a sensible solution to the problem at hand?
- what is the "proper" naming convention and grouping for CLI arguments? IMO it didn't fit `Deamon` nor `Build` struct yet I don't feel very comfortable expanding the main `Plugin` struct
- is it possible to extract information from executed commands? I'd like to capture the loaded image tag and use it in further plugin execution, but not sure if this is sensibly doable with the command pattern architecture of the plugin.

The current ad hoc proposed API is:
```yaml
load_image: true
load_image_location: ./foo/bar.tar.gz
load_image_tag: my-builded-image:latest # this is the tag of the zipped image, required for re-tagging it once it's loaded
```