### PR TITLE
Added env-file with godotenv to all non-base implementations of plugin

### DIFF
--- a/cmd/drone-acr/main.go
+++ b/cmd/drone-acr/main.go
@@ -5,9 +5,16 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/joho/godotenv"
 )
 
 func main() {
+	// Load env-file if it exists first
+	if env := os.Getenv("PLUGIN_ENV_FILE"); env != "" {
+		godotenv.Load(env)
+	}
+
 	var (
 		repo     = getenv("PLUGIN_REPO")
 		registry = getenv("PLUGIN_REGISTRY")

--- a/cmd/drone-ecr/main.go
+++ b/cmd/drone-ecr/main.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/joho/godotenv"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
@@ -20,6 +22,11 @@ import (
 const defaultRegion = "us-east-1"
 
 func main() {
+	// Load env-file if it exists first
+	if env := os.Getenv("PLUGIN_ENV_FILE"); env != "" {
+		godotenv.Load(env)
+	}
+
 	var (
 		repo             = getenv("PLUGIN_REPO")
 		registry         = getenv("PLUGIN_REGISTRY")

--- a/cmd/drone-gcr/main.go
+++ b/cmd/drone-gcr/main.go
@@ -6,12 +6,19 @@ import (
 	"os/exec"
 	"path"
 	"strings"
+
+	"github.com/joho/godotenv"
 )
 
 // gcr default username
 const username = "_json_key"
 
 func main() {
+	// Load env-file if it exists first
+	if env := os.Getenv("PLUGIN_ENV_FILE"); env != "" {
+		godotenv.Load(env)
+	}
+
 	var (
 		repo     = getenv("PLUGIN_REPO")
 		registry = getenv("PLUGIN_REGISTRY")

--- a/cmd/drone-heroku/main.go
+++ b/cmd/drone-heroku/main.go
@@ -4,9 +4,16 @@ import (
 	"os"
 	"os/exec"
 	"path"
+
+	"github.com/joho/godotenv"
 )
 
 func main() {
+	// Load env-file if it exists first
+	if env := os.Getenv("PLUGIN_ENV_FILE"); env != "" {
+		godotenv.Load(env)
+	}
+
 	var (
 		registry = "registry.heroku.com"
 		process  = getenv("PLUGIN_PROCESS_TYPE")


### PR DESCRIPTION
I found that this didn't work for the Drone ECR plugin, as it was missing the `godotenv` getting environment variables from an env-file.