### PR TITLE
ECR: adding setting to enable image scanning while repo creation

### DIFF
--- a/cmd/drone-ecr/main.go
+++ b/cmd/drone-ecr/main.go
@@ -77,6 +77,10 @@ func main() {
 		if err != nil {
 			log.Fatal(fmt.Sprintf("error creating ECR repo: %v", err))
 		}
+		err = updateImageScannningConfig(svc, trimHostname(repo, registry), scanOnPush)
+		if err != nil {
+			log.Fatal(fmt.Sprintf("error updating scan on push for ECR repo: %v", err))
+		}
 	}
 
 	if lifecyclePolicy != "" {
@@ -132,6 +136,15 @@ func ensureRepoExists(svc *ecr.ECR, name string, scanOnPush bool) (err error) {
 	}
 
 	return
+}
+
+func updateImageScannningConfig(svc *ecr.ECR, name string, scanOnPush bool) (err error) {
+	input := &ecr.PutImageScanningConfigurationInput{}
+	input.SetRepositoryName(name)
+	input.SetImageScanningConfiguration(&ecr.ImageScanningConfiguration{ScanOnPush: &scanOnPush})
+	_, err = svc.PutImageScanningConfiguration(input)
+
+	return err
 }
 
 func uploadLifeCyclePolicy(svc *ecr.ECR, lifecyclePolicy string, name string) (err error) {


### PR DESCRIPTION
Hello!
AWS has added support of automatic ECR images scanning for vulnerabilities last year(https://aws.amazon.com/about-aws/whats-new/2019/10/announcing-image-scanning-for-amazon-ecr/). This can be enabled during repo creation or for already existing repos.

I have a lot of ECR repos created by ecr-plugin via  **"create_repository: true"** setting. 
But I run into the problem when I wanted to enable image scanning on all this repos. As these repos were created/managed by ecr-plugin I think it would be mistake to manage scan setting for these repos with some other automation tool like terraform. Because this increase complexity and split management of ECR repos between two tools.

So I've added new setting **scan_on_push** which is false by default. When you have this setting set to **true** together with **"create_repository: true"** ecr-plugin will create repo with enabled image scanning:
```
steps:
  - name: image-push
    image: plugins/ecr
    settings:
      registry: 000000000000.dkr.ecr.eu-north-1.amazonaws.com
      region: eu-north-1
      dockerfile: ecr/Dockerfile
      repo: ecr-test/alpine
      create_repository: true
      scan_on_push: true
      tags:
        - latest
``` 
  

Update: I have added possibility not only to enable image scanning during repo creation but for already created by ecr-plugin repos. So changing **scan_on_push** setting will be respected any time you change it in your pipeline.
   
