### PR TITLE
Upgrade docker-dind to 19.03.13

### DIFF
--- a/docker/docker/Dockerfile.linux.amd64
+++ b/docker/docker/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM docker:19.03.8-dind
+FROM docker:19.03.13-dind
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 

--- a/docker/docker/Dockerfile.linux.arm
+++ b/docker/docker/Dockerfile.linux.arm
@@ -1,4 +1,4 @@
-FROM arm32v6/docker:19.03.08-dind
+FROM arm32v6/docker:19.03.8-dind
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 

--- a/docker/docker/Dockerfile.linux.arm
+++ b/docker/docker/Dockerfile.linux.arm
@@ -1,4 +1,4 @@
-FROM arm32v6/docker:19.03.13-dind
+FROM arm32v6/docker:19.03.08-dind
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 

--- a/docker/docker/Dockerfile.linux.arm
+++ b/docker/docker/Dockerfile.linux.arm
@@ -1,4 +1,4 @@
-FROM arm32v6/docker:19.03.8-dind
+FROM arm32v6/docker:19.03.13-dind
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 

--- a/docker/docker/Dockerfile.linux.arm64
+++ b/docker/docker/Dockerfile.linux.arm64
@@ -1,4 +1,4 @@
-FROM arm64v8/docker:19.03.8-dind
+FROM arm64v8/docker:19.03.13-dind
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 


### PR DESCRIPTION
Docker based plugins are currently broken. This PR upgrades the base image to use 19.03.13

https://discourse.drone.io/t/broken-builds-with-docker-19-03-13/8373/7