### PR TITLE
feature: added support the autolabel env variable for acr/ecr/gcr/heroku

### DIFF
--- a/cmd/drone-acr/main.go
+++ b/cmd/drone-acr/main.go
@@ -16,10 +16,11 @@ func main() {
 	}
 
 	var (
-		repo     = getenv("PLUGIN_REPO")
-		registry = getenv("PLUGIN_REGISTRY")
-		username = getenv("SERVICE_PRINCIPAL_CLIENT_ID")
-		password = getenv("SERVICE_PRINCIPAL_CLIENT_SECRET")
+		repo      = getenv("PLUGIN_REPO")
+		registry  = getenv("PLUGIN_REGISTRY")
+		username  = getenv("SERVICE_PRINCIPAL_CLIENT_ID")
+		password  = getenv("SERVICE_PRINCIPAL_CLIENT_SECRET")
+		autolabel = getenv("PLUGIN_AUTO_LABEL")
 	)
 
 	// default registry value
@@ -35,6 +36,7 @@ func main() {
 	}
 
 	os.Setenv("PLUGIN_REPO", repo)
+	os.Setenv("PLUGIN_AUTO_LABEL", autolabel)
 	os.Setenv("PLUGIN_REGISTRY", registry)
 	os.Setenv("DOCKER_USERNAME", username)
 	os.Setenv("DOCKER_PASSWORD", password)

--- a/cmd/drone-ecr/main.go
+++ b/cmd/drone-ecr/main.go
@@ -38,6 +38,7 @@ func main() {
 		repositoryPolicy = getenv("PLUGIN_REPOSITORY_POLICY")
 		assumeRole       = getenv("PLUGIN_ASSUME_ROLE")
 		scanOnPush       = parseBoolOrDefault(false, getenv("PLUGIN_SCAN_ON_PUSH"))
+		autolabel        = getenv("PLUGIN_AUTO_LABEL")
 	)
 
 	// set the region
@@ -104,6 +105,7 @@ func main() {
 	}
 
 	os.Setenv("PLUGIN_REPO", repo)
+	os.Setenv("PLUGIN_AUTO_LABEL", autolabel)
 	os.Setenv("PLUGIN_REGISTRY", registry)
 	os.Setenv("DOCKER_USERNAME", username)
 	os.Setenv("DOCKER_PASSWORD", password)

--- a/cmd/drone-gcr/main.go
+++ b/cmd/drone-gcr/main.go
@@ -20,14 +20,15 @@ func main() {
 	}
 
 	var (
-		repo     = getenv("PLUGIN_REPO")
-		registry = getenv("PLUGIN_REGISTRY")
-		password = getenv(
+		repo      = getenv("PLUGIN_REPO")
+		registry  = getenv("PLUGIN_REGISTRY")
+		password  = getenv(
 			"PLUGIN_JSON_KEY",
 			"GCR_JSON_KEY",
 			"GOOGLE_CREDENTIALS",
 			"TOKEN",
 		)
+		autolabel = getenv("PLUGIN_AUTO_LABEL")
 	)
 
 	// decode the token if base64 encoded
@@ -49,6 +50,7 @@ func main() {
 	}
 
 	os.Setenv("PLUGIN_REPO", repo)
+	os.Setenv("PLUGIN_AUTO_LABEL", autolabel)
 	os.Setenv("PLUGIN_REGISTRY", registry)
 	os.Setenv("DOCKER_USERNAME", username)
 	os.Setenv("DOCKER_PASSWORD", password)

--- a/cmd/drone-heroku/main.go
+++ b/cmd/drone-heroku/main.go
@@ -15,11 +15,12 @@ func main() {
 	}
 
 	var (
-		registry = "registry.heroku.com"
-		process  = getenv("PLUGIN_PROCESS_TYPE")
-		app      = getenv("PLUGIN_APP")
-		email    = getenv("PLUGIN_EMAIL", "HEROKU_EMAIL")
-		key      = getenv("PLUGIN_API_KEY", "HEROKU_API_KEY")
+		registry  = "registry.heroku.com"
+		process   = getenv("PLUGIN_PROCESS_TYPE")
+		app       = getenv("PLUGIN_APP")
+		email     = getenv("PLUGIN_EMAIL", "HEROKU_EMAIL")
+		key       = getenv("PLUGIN_API_KEY", "HEROKU_API_KEY")
+		autolabel = getenv("PLUGIN_AUTO_LABEL")
 	)
 
 	if process == "" {
@@ -28,6 +29,7 @@ func main() {
 
 	os.Setenv("PLUGIN_REGISTRY", registry)
 	os.Setenv("PLUGIN_REPO", path.Join(registry, app, process))
+	os.Setenv("PLUGIN_AUTO_LABEL", autolabel)
 
 	os.Setenv("DOCKER_PASSWORD", key)
 	os.Setenv("DOCKER_USERNAME", email)


### PR DESCRIPTION
In plugin versions acr/ecr/gcr/heroku "auto_label: false" does not work.
Added support for this parameter 

```yaml
  - name: build-and-push
    image: plugins/ecr:19.03.8
    settings:
      ...
      auto_label: false
```
Before:
```sh
/usr/local/bin/docker build --rm=true -f Dockerfile -t ..b7c17b2.. . --pull=true --label org.label-schema.schema-version=1.0 --label org.label-schema.build-date=2021-04-11T19:18:47Z --label org.label-schema.vcs-ref=..b7c17b2.. --label org.label-schema.vcs-url=https://github.com/user/repo.git
```
After:
```sh
/usr/local/bin/docker build --rm=true -f Dockerfile -t ..b7c17b2.. . --pull=true
```