### PR TITLE
Adds support for additional registry credentials

### DIFF
--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -219,19 +219,19 @@ func main() {
 			EnvVar: "PLUGIN_PASSWORD,DOCKER_PASSWORD",
 		},
 		cli.StringFlag{
-			Name:   "docker.registry.alternative",
-			Usage:  "docker alternative registry",
-			EnvVar: "PLUGIN_REGISTRY_ALTERNATIVE,DOCKER_REGISTRY_ALTERNATIVE",
+			Name:   "docker.registry.additional",
+			Usage:  "docker additional registry",
+			EnvVar: "PLUGIN_REGISTRY_ADDITIONAL,DOCKER_REGISTRY_ADDITIONAL",
 		},
 		cli.StringFlag{
-			Name:   "docker.username.alternative",
-			Usage:  "docker username for alternative registry",
-			EnvVar: "PLUGIN_USERNAME_ALTERNATIVE,DOCKER_USERNAME_ALTERNATIVE",
+			Name:   "docker.username.additional",
+			Usage:  "docker username for additional registry",
+			EnvVar: "PLUGIN_USERNAME_ADDITIONAL,DOCKER_USERNAME_ADDITIONAL",
 		},
 		cli.StringFlag{
-			Name:   "docker.password.alternative",
-			Usage:  "docker password for alternative registry",
-			EnvVar: "PLUGIN_PASSWORD_ALTERNATIVE,DOCKER_PASSWORD_ALTERNATIVE",
+			Name:   "docker.password.additional",
+			Usage:  "docker password for additional registry",
+			EnvVar: "PLUGIN_PASSWORD_ADDITIONAL,DOCKER_PASSWORD_ADDITIONAL",
 		},
 		cli.StringFlag{
 			Name:   "docker.email",
@@ -281,10 +281,10 @@ func run(c *cli.Context) error {
 			Email:    c.String("docker.email"),
 			Config:   c.String("docker.config"),
 		},
-		LoginAlt: docker.LoginAlt{
-			Registry: c.String("docker.registry.alternative"),
-			Username: c.String("docker.username.alternative"),
-			Password: c.String("docker.password.alternative")
+		LoginAdd: docker.LoginAdd{
+			Registry: c.String("docker.registry.additional"),
+			Username: c.String("docker.username.additional"),
+			Password: c.String("docker.password.additional")
 		},		
 		Build: docker.Build{
 			Remote:        c.String("remote.url"),

--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -219,6 +219,21 @@ func main() {
 			EnvVar: "PLUGIN_PASSWORD,DOCKER_PASSWORD",
 		},
 		cli.StringFlag{
+			Name:   "docker.registry.alternative",
+			Usage:  "docker alternative registry",
+			EnvVar: "PLUGIN_REGISTRY_ALTERNATIVE,DOCKER_REGISTRY_ALTERNATIVE",
+		},
+		cli.StringFlag{
+			Name:   "docker.username.alternative",
+			Usage:  "docker username for alternative registry",
+			EnvVar: "PLUGIN_USERNAME_ALTERNATIVE,DOCKER_USERNAME_ALTERNATIVE",
+		},
+		cli.StringFlag{
+			Name:   "docker.password.alternative",
+			Usage:  "docker password for alternative registry",
+			EnvVar: "PLUGIN_PASSWORD_ALTERNATIVE,DOCKER_PASSWORD_ALTERNATIVE",
+		},
+		cli.StringFlag{
 			Name:   "docker.email",
 			Usage:  "docker email",
 			EnvVar: "PLUGIN_EMAIL,DOCKER_EMAIL",
@@ -266,6 +281,11 @@ func run(c *cli.Context) error {
 			Email:    c.String("docker.email"),
 			Config:   c.String("docker.config"),
 		},
+		LoginAlt: docker.LoginAlt{
+			Registry: c.String("docker.registry.alternative"),
+			Username: c.String("docker.username.alternative"),
+			Password: c.String("docker.password.alternative")
+		},		
 		Build: docker.Build{
 			Remote:        c.String("remote.url"),
 			Name:          c.String("commit.sha"),

--- a/docker.go
+++ b/docker.go
@@ -37,6 +37,13 @@ type (
 		Config   string // Docker Auth Config
 	}
 
+	// LoginAlt defines Docker login parameters for a secondary registry
+	LoginAlt struct {
+		Registry string // Docker registry address
+		Username string // Docker registry username
+		Password string // Docker registry password
+	}
+
 	// Build defines Docker build parameters.
 	Build struct {
 		Remote        string   // Git remote URL
@@ -63,11 +70,12 @@ type (
 
 	// Plugin defines the Docker plugin parameters.
 	Plugin struct {
-		Login   Login  // Docker login configuration
-		Build   Build  // Docker build configuration
-		Daemon  Daemon // Docker daemon configuration
-		Dryrun  bool   // Docker push is skipped
-		Cleanup bool   // Docker purge is enabled
+		Login    Login  // Docker login configuration
+		LoginAlt LoginAlt // Docker login configuration for secondary registry
+		Build    Build  // Docker build configuration
+		Daemon   Daemon // Docker daemon configuration
+		Dryrun   bool   // Docker push is skipped
+		Cleanup  bool   // Docker purge is enabled
 	}
 )
 
@@ -103,6 +111,16 @@ func (p Plugin) Exec() error {
 	// login to the Docker registry
 	if p.Login.Password != "" {
 		cmd := commandLogin(p.Login)
+		err := cmd.Run()
+		if err != nil {
+			return fmt.Errorf("Error authenticating: %s", err)
+		}
+	}
+	
+	// login to secondary registry
+	if p.LoginAlt.Password != "" {
+		fmt.Println("Detected alternative registry credentials")
+		cmd := commandLogin(p.LoginAlt)
 		err := cmd.Run()
 		if err != nil {
 			return fmt.Errorf("Error authenticating: %s", err)

--- a/docker.go
+++ b/docker.go
@@ -42,6 +42,8 @@ type (
 		Registry string // Docker registry address
 		Username string // Docker registry username
 		Password string // Docker registry password
+		Email    string // Docker registry email
+		Config   string // Docker Auth Config
 	}
 
 	// Build defines Docker build parameters.

--- a/docker.go
+++ b/docker.go
@@ -37,8 +37,8 @@ type (
 		Config   string // Docker Auth Config
 	}
 
-	// LoginAlt defines Docker login parameters for a secondary registry
-	LoginAlt struct {
+	// LoginAdd defines Docker login parameters for an additional registry
+	LoginAdd struct {
 		Registry string // Docker registry address
 		Username string // Docker registry username
 		Password string // Docker registry password
@@ -70,12 +70,12 @@ type (
 
 	// Plugin defines the Docker plugin parameters.
 	Plugin struct {
-		Login    Login  // Docker login configuration
-		LoginAlt LoginAlt // Docker login configuration for secondary registry
-		Build    Build  // Docker build configuration
-		Daemon   Daemon // Docker daemon configuration
-		Dryrun   bool   // Docker push is skipped
-		Cleanup  bool   // Docker purge is enabled
+		Login    Login  	// Docker login configuration
+		LoginAdd LoginAdd 	// Docker login configuration for an additional registry
+		Build    Build  	// Docker build configuration
+		Daemon   Daemon 	// Docker daemon configuration
+		Dryrun   bool   	// Docker push is skipped
+		Cleanup  bool   	// Docker purge is enabled
 	}
 )
 
@@ -117,10 +117,10 @@ func (p Plugin) Exec() error {
 		}
 	}
 	
-	// login to secondary registry
-	if p.LoginAlt.Password != "" {
-		fmt.Println("Detected alternative registry credentials")
-		cmd := commandLogin(p.LoginAlt)
+	// login to additional registry
+	if p.LoginAdd.Password != "" {
+		fmt.Println("Detected additional registry credentials")
+		cmd := commandLogin(p.LoginAdd)
 		err := cmd.Run()
 		if err != nil {
 			return fmt.Errorf("Error authenticating: %s", err)


### PR DESCRIPTION
Usecase: situation where the `FROM` image is pulled from a registry that needs a different set of credentials than the registry where the image will be pushed towards.

For example, when using Nexus as a pass-through proxy for base images.