### PR TITLE
Add DRONE_REPO for repo cli param

### DIFF
--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -180,7 +180,7 @@ func main() {
 		cli.StringFlag{
 			Name:   "repo",
 			Usage:  "docker repository",
-			EnvVar: "PLUGIN_REPO",
+			EnvVar: "PLUGIN_REPO,DRONE_REPO",
 		},
 		cli.StringSliceFlag{
 			Name:   "custom-labels",


### PR DESCRIPTION
With this addition if repo is not set in settings, the plugin uses the DRONE_REPO environment variable