### PR TITLE
Add support for multiple Buildkit secrets with env vars or files as source

### DIFF
--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -254,6 +254,16 @@ func main() {
 			Usage:  "secret key value pair eg id=MYSECRET",
 			EnvVar: "PLUGIN_SECRET",
 		},
+		cli.StringSliceFlag{
+			Name:   "secrets-from-env",
+			Usage:  "secret key value pair eg secret_name=secret",
+			EnvVar: "PLUGIN_SECRETS_FROM_ENV",
+		},
+		cli.StringSliceFlag{
+			Name:   "secrets-from-file",
+			Usage:  "secret key value pairs eg secret_name=/path/to/secret",
+			EnvVar: "PLUGIN_SECRETS_FROM_FILE",
+		},
 		cli.StringFlag{
 			Name:   "drone-card-path",
 			Usage:  "card path location to write to",
@@ -298,6 +308,8 @@ func run(c *cli.Context) error {
 			Link:        c.String("link"),
 			NoCache:     c.Bool("no-cache"),
 			Secret:      c.String("secret"),
+			SecretEnvs:  c.StringSlice("secrets-from-env"),
+			SecretFiles: c.StringSlice("secrets-from-file"),
 			AddHost:     c.StringSlice("add-host"),
 			Quiet:       c.Bool("quiet"),
 		},

--- a/docker_test.go
+++ b/docker_test.go
@@ -1,1 +1,130 @@
 package docker
+
+import (
+	"os/exec"
+	"reflect"
+	"testing"
+)
+
+func TestCommandBuild(t *testing.T) {
+	tcs := []struct {
+		name  string
+		build Build
+		want  *exec.Cmd
+	}{
+		{
+			name: "secret from env var",
+			build: Build{
+				Name:       "plugins/drone-docker:latest",
+				Dockerfile: "Dockerfile",
+				Context:    ".",
+				SecretEnvs: []string{
+					"foo_secret=FOO_SECRET_ENV_VAR",
+				},
+			},
+			want: exec.Command(
+				dockerExe,
+				"build",
+				"--rm=true",
+				"-f",
+				"Dockerfile",
+				"-t",
+				"plugins/drone-docker:latest",
+				".",
+				"--secret id=foo_secret,env=FOO_SECRET_ENV_VAR",
+			),
+		},
+		{
+			name: "secret from file",
+			build: Build{
+				Name:       "plugins/drone-docker:latest",
+				Dockerfile: "Dockerfile",
+				Context:    ".",
+				SecretFiles: []string{
+					"foo_secret=/path/to/foo_secret",
+				},
+			},
+			want: exec.Command(
+				dockerExe,
+				"build",
+				"--rm=true",
+				"-f",
+				"Dockerfile",
+				"-t",
+				"plugins/drone-docker:latest",
+				".",
+				"--secret id=foo_secret,src=/path/to/foo_secret",
+			),
+		},
+		{
+			name: "multiple mixed secrets",
+			build: Build{
+				Name:       "plugins/drone-docker:latest",
+				Dockerfile: "Dockerfile",
+				Context:    ".",
+				SecretEnvs: []string{
+					"foo_secret=FOO_SECRET_ENV_VAR",
+					"bar_secret=BAR_SECRET_ENV_VAR",
+				},
+				SecretFiles: []string{
+					"foo_secret=/path/to/foo_secret",
+					"bar_secret=/path/to/bar_secret",
+				},
+			},
+			want: exec.Command(
+				dockerExe,
+				"build",
+				"--rm=true",
+				"-f",
+				"Dockerfile",
+				"-t",
+				"plugins/drone-docker:latest",
+				".",
+				"--secret id=foo_secret,env=FOO_SECRET_ENV_VAR",
+				"--secret id=bar_secret,env=BAR_SECRET_ENV_VAR",
+				"--secret id=foo_secret,src=/path/to/foo_secret",
+				"--secret id=bar_secret,src=/path/to/bar_secret",
+			),
+		},
+		{
+			name: "invalid mixed secrets",
+			build: Build{
+				Name:       "plugins/drone-docker:latest",
+				Dockerfile: "Dockerfile",
+				Context:    ".",
+				SecretEnvs: []string{
+					"foo_secret=",
+					"=FOO_SECRET_ENV_VAR",
+					"",
+				},
+				SecretFiles: []string{
+					"foo_secret=",
+					"=/path/to/bar_secret",
+					"",
+				},
+			},
+			want: exec.Command(
+				dockerExe,
+				"build",
+				"--rm=true",
+				"-f",
+				"Dockerfile",
+				"-t",
+				"plugins/drone-docker:latest",
+				".",
+			),
+		},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := commandBuild(tc.build)
+
+			if !reflect.DeepEqual(cmd.String(), tc.want.String()) {
+				t.Errorf("Got cmd %v, want %v", cmd, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#356 introduced the possibility to use the Buildkit secrets feature when building the Docker image. However, it's not possible to specify more than one secret due to the fact that the setting is a simple string that gets used as value of the `--secret` CLI arg. I wasn't also happy with the fact that the `secret` setting was basically just the plain value of the arg, leading people to need the knowledge of the syntax of the `docker build` command to use it. For this reason, I splitted the setting into two: `secrets_from_env` and `secrets_from_file`. These new settings are just a list of strings in the format `key=value`, where the key is the name of the secret and the value can be the name of an environment variable or a file path. This PR also supersedes #332 somewhat.

### Example usage

- `Dockerfile`:
  ```dockerfile
  # syntax=docker/dockerfile:1.2
  FROM alpine
  RUN --mount=type=secret,id=foo_secret cat /run/secrets/foo_secret
  RUN --mount=type=secret,id=bar_secret cat /run/secrets/bar_secret
  RUN --mount=type=secret,id=baz_secret cat /run/secrets/baz_secret
  ```

- `.drone.yml`
  ```yaml
  kind: pipeline
  type: docker
  name: test

  steps:
    - name: dist
      image: plugins/drone-docker
      environment:
        FOO_SECRET:
          from_secret: FOO_SECRET
        BAR_SECRET:
          from_secret: BAR_SECRET
      settings:
        secrets_from_env:
          - foo_secret=FOO_SECRET
          - bar_secret=BAR_SECRET
        secrets_from_file:
          - baz_secret=baz_secret.txt
  ```