### PR TITLE
Dry-run instead of skip, when auto_tag: true and no tag is matched

### DIFF
--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -333,8 +333,8 @@ func run(c *cli.Context) error {
 			}
 			plugin.Build.Tags = tag
 		} else {
-			logrus.Printf("skipping automated docker build for %s", c.String("commit.ref"))
-			return nil
+			logrus.Printf("dry-running automated docker build for %s", c.String("commit.ref"))
+			plugin.Dryrun = true
 		}
 	}
 


### PR DESCRIPTION
This safely allows to check larger parts of the build
earlier (e.g. during a pull request).

This is changes existing behavior, but this is IMHO better than
introducing yet another option. Mainly for the following reasons:

- This is the behavior I'd expect.
- The old behavior can be easily recreated using `when.ref`.


