### PR TITLE
Add support for docker --platform flag

### DIFF
--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -269,6 +269,11 @@ func main() {
 			Usage:  "card path location to write to",
 			EnvVar: "DRONE_CARD_PATH",
 		},
+		cli.StringFlag{
+			Name:   "platform",
+			Usage:  "platform value to pass to docker",
+			EnvVar: "PLUGIN_PLATFORM",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -312,6 +317,7 @@ func run(c *cli.Context) error {
 			SecretFiles: c.StringSlice("secrets-from-file"),
 			AddHost:     c.StringSlice("add-host"),
 			Quiet:       c.Bool("quiet"),
+			Platform:    c.String("platform"),
 		},
 		Daemon: docker.Daemon{
 			Registry:      c.String("docker.registry"),

--- a/docker.go
+++ b/docker.go
@@ -63,6 +63,7 @@ type (
 		SecretFiles []string // Docker build secrets with file as source
 		AddHost     []string // Docker build add-host
 		Quiet       bool     // Docker build quiet
+		Platform    string   // Docker build platform
 	}
 
 	// Plugin defines the Docker plugin parameters.
@@ -323,6 +324,9 @@ func commandBuild(build Build) *exec.Cmd {
 	}
 	if build.Quiet {
 		args = append(args, "--quiet")
+	}
+	if build.Platform != "" {
+		args = append(args, "--platform", build.Platform)
 	}
 
 	if build.AutoLabel {

--- a/docker_test.go
+++ b/docker_test.go
@@ -114,6 +114,27 @@ func TestCommandBuild(t *testing.T) {
 				".",
 			),
 		},
+		{
+			name: "platform argument",
+			build: Build{
+				Name:       "plugins/drone-docker:latest",
+				Dockerfile: "Dockerfile",
+				Context:    ".",
+				Platform:   "test/platform",
+			},
+			want: exec.Command(
+				dockerExe,
+				"build",
+				"--rm=true",
+				"-f",
+				"Dockerfile",
+				"-t",
+				"plugins/drone-docker:latest",
+				".",
+				"--platform",
+				"test/platform",
+			),
+		},
 	}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
Add a --platform flag so that the user can specify a value for the
corresponding flag passed to docker. This is useful in the context of
multi-arch builds and buildkit (DOCKER_BUILDKIT=1 in the environment).

Signed-off-by: Marcelo E. Magallon <marcelo.magallon@grafana.com>


