### PR TITLE
[Feature] support keep intermediate container for multi-stage build caching

### DIFF
--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -153,6 +153,11 @@ func main() {
 			Usage:  "quiet docker build",
 			EnvVar: "PLUGIN_QUIET",
 		},
+		cli.BoolFlag{
+			Name:   "ignore-rm",
+			Usage:  "remove intermediate container",
+			EnvVar: "PLUGIN_IGNORE_RM",
+		},
 		cli.StringFlag{
 			Name:   "target",
 			Usage:  "build target",
@@ -312,6 +317,7 @@ func run(c *cli.Context) error {
 			SecretFiles: c.StringSlice("secrets-from-file"),
 			AddHost:     c.StringSlice("add-host"),
 			Quiet:       c.Bool("quiet"),
+			IgnoreRm:    c.Bool("ignore-rm"),
 		},
 		Daemon: docker.Daemon{
 			Registry:      c.String("docker.registry"),

--- a/docker.go
+++ b/docker.go
@@ -63,6 +63,7 @@ type (
 		SecretFiles []string // Docker build secrets with file as source
 		AddHost     []string // Docker build add-host
 		Quiet       bool     // Docker build quiet
+		IgnoreRm    bool     // Docker build rm
 	}
 
 	// Plugin defines the Docker plugin parameters.
@@ -275,10 +276,16 @@ func commandInfo() *exec.Cmd {
 func commandBuild(build Build) *exec.Cmd {
 	args := []string{
 		"build",
-		"--rm=true",
+	}
+
+	if !build.IgnoreRm {
+		args = append(args, "--rm=true")
+	}
+
+	args = append(args, []string{
 		"-f", build.Dockerfile,
 		"-t", build.Name,
-	}
+	}...)
 
 	args = append(args, build.Context)
 	if build.Squash {

--- a/docker_test.go
+++ b/docker_test.go
@@ -114,6 +114,28 @@ func TestCommandBuild(t *testing.T) {
 				".",
 			),
 		},
+		{
+			name: "build without rm",
+			build: Build{
+				Name:       "plugins/drone-docker:latest",
+				Dockerfile: "Dockerfile",
+				Context:    ".",
+				SecretEnvs: []string{
+					"foo_secret=FOO_SECRET_ENV_VAR",
+				},
+				IgnoreRm: true,
+			},
+			want: exec.Command(
+				dockerExe,
+				"build",
+				"-f",
+				"Dockerfile",
+				"-t",
+				"plugins/drone-docker:latest",
+				".",
+				"--secret id=foo_secret,env=FOO_SECRET_ENV_VAR",
+			),
+		},
 	}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
fore using `--rm=true` makes trouble for multiple stage build. The `always remove intermediate container` behavior prevents people to speed up their building.

Here is the screenshot when --rm=true.
<img width="975" alt="image" src="https://user-images.githubusercontent.com/32964977/172878436-7d2db052-276e-4d9a-9498-14346d45deee.png">

And it should be cached as it's built in jenkins

<img width="761" alt="image" src="https://user-images.githubusercontent.com/32964977/172878637-31015992-1316-4da9-945b-6ed39195e5a6.png">



