### PR TITLE
enable ssh agent

### DIFF
--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -264,7 +264,7 @@ func main() {
 			Usage:  "secret key value pairs eg secret_name=/path/to/secret",
 			EnvVar: "PLUGIN_SECRETS_FROM_FILE",
 		},
-		cli.StringSliceFlag{
+		cli.StringFlag{
 			Name:   "ssh-agent",
 			Usage:  "mount ssh agent",
 			EnvVar: "PLUGIN_SSH_AGENT",

--- a/docker.go
+++ b/docker.go
@@ -543,9 +543,8 @@ func writeSSHPrivateKey() error {
 	if privateKeyBase64 == "" {
 		return fmt.Errorf("%s must be defined and contain the base64 encoded private key to use for ssh agent forwarding", SSHPrivateKeyFromEnv)
 	}
-	privateKey := []byte{}
 	var err error
-	_, err = base64.StdEncoding.Decode(privateKey, []byte(privateKeyBase64))
+	privateKey, err := base64.StdEncoding.DecodeString(privateKeyBase64)
 	if err != nil {
 		return fmt.Errorf("unable to base64 decode private key")
 	}

--- a/docker.go
+++ b/docker.go
@@ -192,6 +192,8 @@ func (p Plugin) Exec() error {
 
 	// setup for using ssh agent (https://docs.docker.com/develop/develop-images/build_enhancements/#using-ssh-to-access-private-data-in-builds)
 	if !sshAgentEmpty(p.Build.SSHAgent) {
+		// TODO check in with one of the drone devs...this should not be necessary. I'm probably doing something
+		// wrong with the cli framework
 		p.Build.SSHAgent = strings.TrimSuffix(p.Build.SSHAgent, "]")
 		p.Build.SSHAgent = strings.TrimPrefix(p.Build.SSHAgent, "[")
 		fmt.Printf("ssh agent set to \"%s\"\n", p.Build.SSHAgent)
@@ -533,7 +535,6 @@ func commandSSHAgentForwardingSetup(build Build) []*exec.Cmd {
 	}
 	os.Setenv("SSH_AUTH_SOCK", SSHAgentSockPath)
 	cmds = append(cmds, exec.Command("ssh-agent", "-a", SSHAgentSockPath))
-	cmds = append(cmds, exec.Command("cat", "/root/.ssh/id_rsa"))
 	cmds = append(cmds, exec.Command("ssh-add"))
 	return cmds
 }

--- a/docker.go
+++ b/docker.go
@@ -191,7 +191,7 @@ func (p Plugin) Exec() error {
 	}
 
 	// setup for using ssh agent (https://docs.docker.com/develop/develop-images/build_enhancements/#using-ssh-to-access-private-data-in-builds)
-	if !sshAgentEmpty(p.Build.SSHAgent) {
+	if p.Build.SSHAgent != "" {
 		// TODO check in with one of the drone devs...this should not be necessary. I'm probably doing something
 		// wrong with the cli framework
 		p.Build.SSHAgent = strings.TrimSuffix(p.Build.SSHAgent, "]")
@@ -346,7 +346,7 @@ func commandBuild(build Build) *exec.Cmd {
 	if build.Quiet {
 		args = append(args, "--quiet")
 	}
-	if !sshAgentEmpty(build.SSHAgent) {
+	if build.SSHAgent != "" {
 		args = append(args, "--ssh", build.SSHAgent)
 	}
 
@@ -375,7 +375,7 @@ func commandBuild(build Build) *exec.Cmd {
 	}
 
 	// we need to enable buildkit, for secret support and ssh agent support
-	if build.Secret != "" || len(build.SecretEnvs) > 0 || len(build.SecretFiles) > 0 || !sshAgentEmpty(build.SSHAgent) {
+	if build.Secret != "" || len(build.SecretEnvs) > 0 || len(build.SecretFiles) > 0 || build.SSHAgent != "" {
 		os.Setenv("DOCKER_BUILDKIT", "1")
 	}
 	return exec.Command(dockerExe, args...)
@@ -574,8 +574,4 @@ func GetDroneDockerExecCmd() string {
 	}
 
 	return "drone-docker"
-}
-
-func sshAgentEmpty(agent string) bool {
-	return agent == ""
 }

--- a/docker.go
+++ b/docker.go
@@ -539,7 +539,9 @@ func writeSSHPrivateKey() error {
 	if err != nil {
 		return fmt.Errorf("unable to determine home directory: %s", err)
 	}
-	os.MkdirAll(filepath.Join(home, ".ssh"), 0700)
+	if err := os.MkdirAll(filepath.Join(home, ".ssh"), 0700); err != nil {
+		return fmt.Errorf("unable to create .ssh directory: %s", err)
+	}
 	if err := os.WriteFile(filepath.Join(home, ".ssh", "id_rsa"), []byte(privateKey), 0400); err != nil {
 		return fmt.Errorf("unable to write ssh key: %s", err)
 	}

--- a/docker.go
+++ b/docker.go
@@ -114,9 +114,6 @@ type (
 // Exec executes the plugin step
 func (p Plugin) Exec() error {
 
-	fmt.Printf("exec build: %#v", p.Build)
-	fmt.Printf("exec env: %#v", os.Environ())
-
 	// start the Docker daemon server
 	if !p.Daemon.Disabled {
 		p.startDaemon()

--- a/docker.go
+++ b/docker.go
@@ -191,6 +191,8 @@ func (p Plugin) Exec() error {
 
 	// setup for using ssh agent (https://docs.docker.com/develop/develop-images/build_enhancements/#using-ssh-to-access-private-data-in-builds)
 	if !sshAgentEmpty(p.Build.SSHAgent) {
+		p.Build.SSHAgent = strings.TrimSuffix(p.Build.SSHAgent, "]")
+		p.Build.SSHAgent = strings.TrimPrefix(p.Build.SSHAgent, "[")
 		fmt.Printf("ssh agent set to \"%s\"", p.Build.SSHAgent)
 		cmds = append(cmds, commandSSHAgentForwardingSetup(p.Build)...)
 	}
@@ -529,7 +531,7 @@ func commandSSHAgentForwardingSetup(build Build) []*exec.Cmd {
 		log.Fatalf("unable to setup ssh agent forwarding: %s", err)
 	}
 	os.Setenv("SSH_AUTH_SOCK", SSHAgentSockPath)
-	cmds = append(cmds, exec.Command("ssh-agent", "-p", SSHAgentSockPath))
+	cmds = append(cmds, exec.Command("ssh-agent", "-a", SSHAgentSockPath))
 	cmds = append(cmds, exec.Command("ssh-add"))
 	return cmds
 }

--- a/docker.go
+++ b/docker.go
@@ -112,6 +112,10 @@ type (
 
 // Exec executes the plugin step
 func (p Plugin) Exec() error {
+
+	fmt.Printf("exec build: %#v", p.Build)
+	fmt.Printf("exec env: %#v", os.Environ())
+
 	// start the Docker daemon server
 	if !p.Daemon.Disabled {
 		p.startDaemon()
@@ -187,6 +191,7 @@ func (p Plugin) Exec() error {
 
 	// setup for using ssh agent (https://docs.docker.com/develop/develop-images/build_enhancements/#using-ssh-to-access-private-data-in-builds)
 	if p.Build.SSHAgent != "" {
+		fmt.Printf("ssh agent set to \"%s\"", p.Build.SSHAgent)
 		cmds = append(cmds, commandSSHAgentForwardingSetup(p.Build)...)
 	}
 

--- a/docker.go
+++ b/docker.go
@@ -568,5 +568,5 @@ func GetDroneDockerExecCmd() string {
 }
 
 func sshAgentEmpty(agent string) bool {
-	return agent == "" || agent == "[]"
+	return agent == ""
 }

--- a/docker.go
+++ b/docker.go
@@ -190,7 +190,7 @@ func (p Plugin) Exec() error {
 	}
 
 	// setup for using ssh agent (https://docs.docker.com/develop/develop-images/build_enhancements/#using-ssh-to-access-private-data-in-builds)
-	if p.Build.SSHAgent != "" {
+	if !sshAgentEmpty(p.Build.SSHAgent) {
 		fmt.Printf("ssh agent set to \"%s\"", p.Build.SSHAgent)
 		cmds = append(cmds, commandSSHAgentForwardingSetup(p.Build)...)
 	}
@@ -341,7 +341,7 @@ func commandBuild(build Build) *exec.Cmd {
 	if build.Quiet {
 		args = append(args, "--quiet")
 	}
-	if build.SSHAgent != "" {
+	if !sshAgentEmpty(build.SSHAgent) {
 		args = append(args, "--ssh", build.SSHAgent)
 	}
 
@@ -370,7 +370,7 @@ func commandBuild(build Build) *exec.Cmd {
 	}
 
 	// we need to enable buildkit, for secret support and ssh agent support
-	if build.Secret != "" || len(build.SecretEnvs) > 0 || len(build.SecretFiles) > 0 || build.SSHAgent != "" {
+	if build.Secret != "" || len(build.SecretEnvs) > 0 || len(build.SecretFiles) > 0 || !sshAgentEmpty(build.SSHAgent) {
 		os.Setenv("DOCKER_BUILDKIT", "1")
 	}
 	return exec.Command(dockerExe, args...)
@@ -565,4 +565,8 @@ func GetDroneDockerExecCmd() string {
 	}
 
 	return "drone-docker"
+}
+
+func sshAgentEmpty(agent string) bool {
+	return agent == "" || agent == "[]"
 }

--- a/docker.go
+++ b/docker.go
@@ -193,7 +193,7 @@ func (p Plugin) Exec() error {
 	if !sshAgentEmpty(p.Build.SSHAgent) {
 		p.Build.SSHAgent = strings.TrimSuffix(p.Build.SSHAgent, "]")
 		p.Build.SSHAgent = strings.TrimPrefix(p.Build.SSHAgent, "[")
-		fmt.Printf("ssh agent set to \"%s\"", p.Build.SSHAgent)
+		fmt.Printf("ssh agent set to \"%s\"\n", p.Build.SSHAgent)
 		cmds = append(cmds, commandSSHAgentForwardingSetup(p.Build)...)
 	}
 
@@ -532,6 +532,7 @@ func commandSSHAgentForwardingSetup(build Build) []*exec.Cmd {
 	}
 	os.Setenv("SSH_AUTH_SOCK", SSHAgentSockPath)
 	cmds = append(cmds, exec.Command("ssh-agent", "-a", SSHAgentSockPath))
+	cmds = append(cmds, exec.Command("cat", "/root/.ssh/id_rsa"))
 	cmds = append(cmds, exec.Command("ssh-add"))
 	return cmds
 }

--- a/docker_test.go
+++ b/docker_test.go
@@ -114,6 +114,26 @@ func TestCommandBuild(t *testing.T) {
 				".",
 			),
 		},
+		{
+			name: "ssh agent",
+			build: Build{
+				Name:       "plugins/drone-docker:latest",
+				Dockerfile: "Dockerfile",
+				Context:    ".",
+				SSHAgent:   "default",
+			},
+			want: exec.Command(
+				dockerExe,
+				"build",
+				"--rm=true",
+				"-f",
+				"Dockerfile",
+				"-t",
+				"plugins/drone-docker:latest",
+				".",
+				"--ssh default",
+			),
+		},
 	}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
Fixes merge conflicts and defects in #336 

Will enable https://docs.docker.com/develop/develop-images/build_enhancements/#using-ssh-to-access-private-data-in-builds

For example with the following starlark snippet:

```
"settings": {
    "registry": "xxx.dkr.ecr.us-east-1.amazonaws.com",
    "repo": "drone-test-build-docker",
    "dockerfile": "Dockerfile.python",
    "custom_dns": "169.254.169.253",
    "ssh_agent": "default",
},
"environment": {
    "SSH_KEY": {
        "from_secret": "SSH_KEY",
    },
}
```

And using the following Dockerfile:

```
FROM python:3.9.0-slim

RUN apt-get update && apt-get install -y  \
    git \
    openssh-client \
    && rm -rf /var/lib/apt/lists/*

RUN mkdir -p -m 0600 ~/.ssh && \
    ssh-keyscan github.com >> ~/.ssh/known_hosts

WORKDIR /workspace

RUN --mount=type=ssh git clone git@github.com:someorg/somerepo.git
```

Please note as in this example its expected that a private, **base64 encoded**, ssh key is provided in the `SSH_KEY` environment variable. You should use drone secret mechanisms accordingly.


