### PR TITLE
Use full path to docker when creating card

### DIFF
--- a/card.go
+++ b/card.go
@@ -18,7 +18,7 @@ import (
 )
 
 func (p Plugin) writeCard() error {
-	cmd := exec.Command("docker", "inspect", p.Build.Name)
+	cmd := exec.Command(dockerExe, "inspect", p.Build.Name)
 	data, err := cmd.CombinedOutput()
 	if err != nil {
 		return err


### PR DESCRIPTION
Windows docker builds failed to create the card using `docker inspect` because docker isn't on the path. Instead use `dockerExec` from `daemon.go` which has the full path to the executable.


