### PR TITLE
Support auto_tag with dry-run when no tag will be created

### DIFF
--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -133,6 +133,11 @@ func main() {
 			Usage:  "default build tags",
 			EnvVar: "PLUGIN_DEFAULT_TAGS,PLUGIN_AUTO_TAG",
 		},
+		cli.BoolFlag{
+			Name:   "tags.auto-with-dry-run",
+			Usage:  "default build tags (like tags.auto, but dry runs in case it wont tag)",
+			EnvVar: "PLUGIN_AUTO_TAG_WITH_DRY_RUN",
+		},
 		cli.StringFlag{
 			Name:   "tags.suffix",
 			Usage:  "default build tags with suffix",
@@ -330,7 +335,7 @@ func run(c *cli.Context) error {
 		},
 	}
 
-	if c.Bool("tags.auto") {
+	if c.Bool("tags.auto") || c.Bool("tags.auto-with-dry-run") {
 		if docker.UseDefaultTag( // return true if tag event or default branch
 			c.String("commit.ref"),
 			c.String("repo.branch"),
@@ -344,6 +349,9 @@ func run(c *cli.Context) error {
 				return err
 			}
 			plugin.Build.Tags = tag
+		} else if c.Bool("tags.auto-with-dry-run") {
+			logrus.Printf("dry-running automated docker build for %s", c.String("commit.ref"))
+			plugin.Dryrun = true
 		} else {
 			logrus.Printf("skipping automated docker build for %s", c.String("commit.ref"))
 			return nil


### PR DESCRIPTION
This safely allows to check larger parts of the build earlier (e.g. during a pull request).

An original version did not introduce an additional flag but changed the existing behavior. However it was rejected because it would break builds relying on non-PR secrets to pull the base images for the build.


