### PR TITLE
fix paracel docker builds using same docker tag issue

### DIFF
--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -44,6 +44,12 @@ func main() {
 			Value:  "00000000",
 		},
 		cli.StringFlag{
+			Name:   "build.name",
+			Usage:  "docker build name",
+			EnvVar: "DRONE_BUILD_NAME",
+			Value:  "",
+		},
+		cli.StringFlag{
 			Name:   "commit.ref",
 			Usage:  "git commit ref",
 			EnvVar: "DRONE_COMMIT_REF",
@@ -334,6 +340,10 @@ func run(c *cli.Context) error {
 			MTU:           c.String("daemon.mtu"),
 			Experimental:  c.Bool("daemon.experimental"),
 		},
+	}
+
+	if c.String("build.name") != "" && len(c.String("build.name")) > 0 {
+		plugin.Build.Name = c.String("build.name")
 	}
 
 	if c.Bool("tags.auto") {


### PR DESCRIPTION
Hi guys:
I have found below errors :
**the first:**
`---> Running in 6590edb5252a
failed to get digest sha256:4ad613a6dc506a0fd79bbb4a803581176292483d3d91e33a3bd1a94195f7bf33: open /home/docker/image/overlay2/imagedb/content/sha256/4ad613a6dc506a0fd79bbb4a803581176292483d3d91e33a3bd1a94195f7bf33: no such file or directory
time="2022-11-30T07:26:32Z" level=fatal msg="exit status 1"`

**the second:**
The image does not include the right binary artifact, when I use `docker inspect` to check the image

**Below is the steps to re produce the above error:**

1. The project has different directory which will generate different binary artifact;
2. When parallel run below command in each of these directory  ,`docker run --rm   --volume=/var/run/docker.sock:/var/run/docker.sock \
  -e PLUGIN_TAG=latest \
  -e PLUGIN_REPO=${project_repo_name} \
  -e DRONE_COMMIT_SHA=07f33938ab35f5d7f812de3de62b87b783707f4d \
  -e PLUGIN_DOCKERFILE=${dockerfile_in_the_different_directory} \
  -v $(pwd):$(pwd) \
  -w $(pwd) \
  --privileged \
  drone-docker  --dry-run`

**The root cause**
All above the two errors are cause by the same docker tag, because we use git commit id as the docker tag, so these different images share the same docker image tag  if we parallel build the project.

**The solutions**
I think we may expose the build.name to the user, if they need to parallel build the project, they can override the value to avoid the issue. 



