### PR TITLE
Add option to mount host ssh agent (--ssh)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 release
 coverage.out
 vendor
+.vscode/
+Dockerfile

--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -274,6 +274,11 @@ func main() {
 			Usage:  "platform value to pass to docker",
 			EnvVar: "PLUGIN_PLATFORM",
 		},
+		cli.StringSliceFlag{
+			Name:   "ssh-agent",
+			Usage:  "mount ssh agent",
+			EnvVar: "PLUGIN_SSH_AGENT",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -318,6 +323,7 @@ func run(c *cli.Context) error {
 			AddHost:     c.StringSlice("add-host"),
 			Quiet:       c.Bool("quiet"),
 			Platform:    c.String("platform"),
+			SSHAgent:    c.StringSlice("ssh-agent"),
 		},
 		Daemon: docker.Daemon{
 			Registry:      c.String("docker.registry"),

--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -274,10 +274,10 @@ func main() {
 			Usage:  "platform value to pass to docker",
 			EnvVar: "PLUGIN_PLATFORM",
 		},
-		cli.StringSliceFlag{
-			Name:   "ssh-agent",
-			Usage:  "mount ssh agent",
-			EnvVar: "PLUGIN_SSH_AGENT",
+		cli.StringFlag{
+			Name:   "ssh-agent-key",
+			Usage:  "ssh agent key to use",
+			EnvVar: "PLUGIN_SSH_AGENT_KEY",
 		},
 	}
 
@@ -323,7 +323,7 @@ func run(c *cli.Context) error {
 			AddHost:     c.StringSlice("add-host"),
 			Quiet:       c.Bool("quiet"),
 			Platform:    c.String("platform"),
-			SSHAgent:    c.StringSlice("ssh-agent"),
+			SSHAgentKey: c.String("ssh-agent-key"),
 		},
 		Daemon: docker.Daemon{
 			Registry:      c.String("docker.registry"),

--- a/daemon.go
+++ b/daemon.go
@@ -1,9 +1,10 @@
+//go:build !windows
 // +build !windows
 
 package docker
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 )
 
@@ -17,8 +18,8 @@ func (p Plugin) startDaemon() {
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 	} else {
-		cmd.Stdout = ioutil.Discard
-		cmd.Stderr = ioutil.Discard
+		cmd.Stdout = io.Discard
+		cmd.Stderr = io.Discard
 	}
 	go func() {
 		trace(cmd)

--- a/docker.go
+++ b/docker.go
@@ -64,6 +64,7 @@ type (
 		AddHost     []string // Docker build add-host
 		Quiet       bool     // Docker build quiet
 		Platform    string   // Docker build platform
+		SSHAgent    []string // Docker build ssh
 	}
 
 	// Plugin defines the Docker plugin parameters.
@@ -327,6 +328,9 @@ func commandBuild(build Build) *exec.Cmd {
 	}
 	if build.Platform != "" {
 		args = append(args, "--platform", build.Platform)
+	}
+	if build.SSHAgent != "" {
+		args = append(args, "--ssh", build.SSHAgent)
 	}
 
 	if build.AutoLabel {

--- a/docker.go
+++ b/docker.go
@@ -1,14 +1,21 @@
 package docker
 
 import (
+	"encoding/base64"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"time"
+)
+
+const (
+	SSHAgentSockPath     = "/tmp/drone-ssh-agent-sock"
+	SSHPrivateKeyFromEnv = "SSH_KEY"
 )
 
 type (
@@ -107,6 +114,7 @@ type (
 
 // Exec executes the plugin step
 func (p Plugin) Exec() error {
+
 	// start the Docker daemon server
 	if !p.Daemon.Disabled {
 		p.startDaemon()
@@ -178,6 +186,13 @@ func (p Plugin) Exec() error {
 	// pre-pull cache images
 	for _, img := range p.Build.CacheFrom {
 		cmds = append(cmds, commandPull(img))
+	}
+
+	// setup for using ssh agent (https://docs.docker.com/develop/develop-images/build_enhancements/#using-ssh-to-access-private-data-in-builds)
+
+	if len(p.Build.SSHAgent) > 0 {
+		fmt.Printf("ssh agent set to \"%s\"\n", p.Build.SSHAgent)
+		cmds = append(cmds, commandSSHAgentForwardingSetup(p.Build)...)
 	}
 
 	cmds = append(cmds, commandBuild(p.Build)) // docker build
@@ -329,8 +344,8 @@ func commandBuild(build Build) *exec.Cmd {
 	if build.Platform != "" {
 		args = append(args, "--platform", build.Platform)
 	}
-	if build.SSHAgent != "" {
-		args = append(args, "--ssh", build.SSHAgent)
+	for _, sshagent := range build.SSHAgent {
+		args = append(args, "--ssh", sshagent)
 	}
 
 	if build.AutoLabel {
@@ -357,8 +372,8 @@ func commandBuild(build Build) *exec.Cmd {
 		}
 	}
 
-	// we need to enable buildkit, for secret support
-	if build.Secret != "" || len(build.SecretEnvs) > 0 || len(build.SecretFiles) > 0 {
+	// we need to enable buildkit, for secret support and ssh agent support
+	if build.Secret != "" || len(build.SecretEnvs) > 0 || len(build.SecretFiles) > 0 || len(build.SSHAgent) > 0 {
 		os.Setenv("DOCKER_BUILDKIT", "1")
 	}
 	return exec.Command(dockerExe, args...)
@@ -509,6 +524,40 @@ func isCommandRmi(args []string) bool {
 
 func commandRmi(tag string) *exec.Cmd {
 	return exec.Command(dockerExe, "rmi", tag)
+}
+
+func commandSSHAgentForwardingSetup(build Build) []*exec.Cmd {
+	cmds := make([]*exec.Cmd, 0)
+	if err := writeSSHPrivateKey(); err != nil {
+		log.Fatalf("unable to setup ssh agent forwarding: %s", err)
+	}
+	os.Setenv("SSH_AUTH_SOCK", SSHAgentSockPath)
+	cmds = append(cmds, exec.Command("ssh-agent", "-a", SSHAgentSockPath))
+	cmds = append(cmds, exec.Command("ssh-add"))
+	return cmds
+}
+
+func writeSSHPrivateKey() error {
+	privateKeyBase64 := os.Getenv(SSHPrivateKeyFromEnv)
+	if privateKeyBase64 == "" {
+		return fmt.Errorf("%s must be defined and contain the base64 encoded private key to use for ssh agent forwarding", SSHPrivateKeyFromEnv)
+	}
+	var err error
+	privateKey, err := base64.StdEncoding.DecodeString(privateKeyBase64)
+	if err != nil {
+		return fmt.Errorf("unable to base64 decode private key")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("unable to determine home directory: %s", err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, ".ssh"), 0700); err != nil {
+		return fmt.Errorf("unable to create .ssh directory: %s", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".ssh", "id_rsa"), privateKey, 0400); err != nil {
+		return fmt.Errorf("unable to write ssh key: %s", err)
+	}
+	return nil
 }
 
 // trace writes each command to stdout with the command wrapped in an xml

--- a/docker_test.go
+++ b/docker_test.go
@@ -135,6 +135,26 @@ func TestCommandBuild(t *testing.T) {
 				"test/platform",
 			),
 		},
+		{
+			name: "ssh agent",
+			build: Build{
+				Name:       "plugins/drone-docker:latest",
+				Dockerfile: "Dockerfile",
+				Context:    ".",
+				SSHKeyPath: "id_rsa=/root/.ssh/id_rsa",
+			},
+			want: exec.Command(
+				dockerExe,
+				"build",
+				"--rm=true",
+				"-f",
+				"Dockerfile",
+				"-t",
+				"plugins/drone-docker:latest",
+				".",
+				"--ssh id_rsa=/root/.ssh/id_rsa",
+			),
+		},
 	}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
This allows adding of multiple ssh keys to a build, 
eg 
```yaml
kind: pipeline
type: docker
name: default
steps:
  - name: docker
    image: plugins/docker:latest
    pull: never
    environment:
    settings:
      dockerfile: Dockerfile
      tags:
        - silly
      repo: tphoney/bash
      ssh_agent_key: LS0tLS1CRUdJTiBPUEVOU1NIIFBSSVZBVEUgS0VZLS0tLS0KYjNCbGJuTnphQzFyWlhrdGRqRUFBQUFBQkc1dmJtVUFBQUFFYm05dVpRQUFBQUFBQUFBQkFBQUJGd0FBQUFkemMyZ3RjbgpOaEFBQUFBd0VBQVFBQUFRRUE0dVZJRTVJUjZmemY4Q1R5N3dVU2UrY25ZTUxHRWJrTEtENWRTYjRqc0ExODlmOE9YSUpzCmYzZHNqWkl4eVoyUHlTU3lLUkNtaHluYk8rajZaSjBPMnVaWWI2VU9EQW5VZGdtMlduUkZIL2xUYkJNN0RMSVh5bG5HYXUKVzVpZm1aVzllem1Sc09XN1JHU2hDSVprNmZZUHRWT1lhTE5WN3ArREZjZkRRcmxETWdMK1hkbWthS3NadTNTZXBYa1VQMwpuMHdPUkdlMExzTm9pcnpCQmcveWdDVTQ0SDBEdjhzUm1OVUZIWEVleWZwOTFRYjQ3UWdCOVVlbERlQXJwQ1BXVHZqMHBUCnJBQlJqU0hpVXpQcXVDZVU4VVpoTnJidjV0VVN4Q1RZclJERERLdDZwWWp1V0tMZUM0czFCbnVDWVdCWSsvaS9pMXFTS3cKaElpckFpdGNsd0FBQThCTTBTK0VUTkV2aEFBQUFBZHpjMmd0Y25OaEFBQUJBUURpNVVnVGtoSHAvTi93SlBMdkJSSjc1eQpkZ3dzWVJ1UXNvUGwxSnZpT3dEWHoxL3c1Y2dteC9kMnlOa2pISm5ZL0pKTElwRUthSEtkczc2UHBrblE3YTVsaHZwUTRNCkNkUjJDYlphZEVVZitWTnNFenNNc2hmS1djWnE1Ym1KK1psYjE3T1pHdzVidEVaS0VJaG1UcDlnKzFVNWhvczFYdW40TVYKeDhOQ3VVTXlBdjVkMmFSb3F4bTdkSjZsZVJRL2VmVEE1RVo3UXV3MmlLdk1FR0QvS0FKVGpnZlFPL3l4R1kxUVVkY1I3SgorbjNWQnZqdENBSDFSNlVONEN1a0k5Wk8rUFNsT3NBRkdOSWVKVE0rcTRKNVR4Um1FMnR1L20xUkxFSk5pdEVNTU1xM3FsCmlPNVlvdDRMaXpVR2U0SmhZRmo3K0wrTFdwSXJDRWlLc0NLMXlYQUFBQUF3RUFBUUFBQVFBRWVSaXVxaGFJVWwvbjBCS3AKKzZPZHBiVDFCMkg0UDNtazFYWHBXa0pCMmtJNFowclZNQTBMaGtNeGwwdzcrVXM0WCt6VE9tek9CVms1R1NLMmtSSVY1cQp5ZnB0VmNEMldNM2l3bUpGeW9nTFhRVDZDK1kxUnN2TkJZa3liUlBZWjBkUkFwV0lzejY1M25IK1JRZ0FSTVdTZ1k5am9RClYwcXRoZXVZMXo1MHNYUFVSTHdZWDJqS252SmJHVHlNVUlya1prS3RwZG5wUnd6ZUZ5L0dUREpnQnVJQmJtbUtWVGdLNFcKR0daOTJScFFxeUo2N081T3RSVW5lQ3hHSEd2TVE5dDJyRnRnRjVrclBXQVl4UXI5K00yQU84YUZZTFBERW40VUlrcnM0TgpSS3Q3eVZveElzd3Z3YUtFM01rZlJDUnY4V1RFNDBkdWpmSmh0dVMyVzJMaEFBQUFnUUNIQ2FqRytTV2hHbThHUzJ6MC9DCkg2U2xGZVZYQm9LYTVkWUhtSTNCWUpMVGJkRytKaFlHUm1OZ1UyeVozayt0dGVMV0ZOdjFmSXVreFRoRVBVRXpidk8xSzcKWm9yMHJ1bkRudzJ4ZUlTa0dzOHBUYlRCblRyc3hXZHZuTHVyeFIrTjBYT2tGc0tsUUw5NFYzK081OHlWSW9PVmN3dWRiMApleUxvYndEeGM1dlFBQUFJRUE4bVM0VytlaTc0SkVtTXBGSlh5VGgwbzBKblZGVFdlUisranRsWGo3NlV3ampKUURLVWpKCkFxblZSdzJzbFFxL2pQbE1DREtZQVBNdnYwOGk1ZDdFUEpXdWRGMldjNHpUY1lPakZDczdGZnc1RXpnVWRra3lNVzh4dkQKdHkxYmxjYTFKSGpadUkvT2RHTXRBYmJIU0R4d0Nxb0tEUGFKOWNpZmFaenlXS1NVc0FBQUNCQU8raDJqYjZFWXJ1WnNicApJMGpDQzczUlRHWFlpbERDUDBQOEpzYVp3OXBsc0cyZm5PNGhxQWI4KzdNQ0JMM0I0aHNHRHNNS2lvTldpM0tUOWpyWmVmClVyZlNEeXJzTndUMmJOd0VaQzlMeGxaU1dONGZCNktPTVp4ZEF3QmdEYlo2UkNXT1BSNEtZaHlOVnhOdmRLaEQveGdyTjQKT3F5VGFIRWZnMkdPOEJabEFBQUFDblJ3UURZNU5GUlJOek09Ci0tLS0tRU5EIE9QRU5TU0ggUFJJVkFURSBLRVktLS0tLQo=
      dry_run: true
```
then in the dockerfile, you can reference particular keys

```yaml
#syntax=docker/dockerfile-upstream:master-experimental

FROM alpine
RUN apk add --no-cache openssh-client \
   && adduser -u 100 -h /example -S example example

USER example
RUN --mount=type=ssh,uid=100 ssh-add -L
```