### PR TITLE
fix: Use unique build name for build and tag

### DIFF
--- a/card.go
+++ b/card.go
@@ -17,8 +17,8 @@ import (
 	"github.com/inhies/go-bytesize"
 )
 
-func (p Plugin) writeCard(buildName string) error {
-	cmd := exec.Command(dockerExe, "inspect", buildName)
+func (p Plugin) writeCard() error {
+	cmd := exec.Command(dockerExe, "inspect", p.Build.TempTag)
 	data, err := cmd.CombinedOutput()
 	if err != nil {
 		return err

--- a/card.go
+++ b/card.go
@@ -17,8 +17,8 @@ import (
 	"github.com/inhies/go-bytesize"
 )
 
-func (p Plugin) writeCard() error {
-	cmd := exec.Command(dockerExe, "inspect", p.Build.Name)
+func (p Plugin) writeCard(buildName string) error {
+	cmd := exec.Command(dockerExe, "inspect", buildName)
 	data, err := cmd.CombinedOutput()
 	if err != nil {
 		return err

--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"math/rand"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/joho/godotenv"
 	"github.com/sirupsen/logrus"
@@ -14,6 +16,7 @@ import (
 
 var (
 	version = "unknown"
+	charset = []byte("abcdefghijklmnopqrstuvwxyz")
 )
 
 func main() {
@@ -318,6 +321,7 @@ func run(c *cli.Context) error {
 		Build: docker.Build{
 			Remote:      c.String("remote.url"),
 			Name:        c.String("commit.sha"),
+			TempTag:     generateTempTag(),
 			Dockerfile:  c.String("dockerfile"),
 			Context:     c.String("context"),
 			Tags:        c.StringSlice("tags"),
@@ -381,6 +385,20 @@ func run(c *cli.Context) error {
 	}
 
 	return plugin.Exec()
+}
+
+func generateTempTag() string {
+	tagLength := 8
+	return randomString(tagLength)
+}
+
+func randomString(n int) string {
+	rand.Seed(time.Now().UTC().UnixNano())
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+	return string(b)
 }
 
 func GetExecCmd() string {

--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -1,22 +1,20 @@
 package main
 
 import (
-	"math/rand"
 	"os"
 	"runtime"
-	"time"
+	"strings"
 
+	"github.com/dchest/uniuri"
+	docker "github.com/drone-plugins/drone-docker"
+	"github.com/drone-plugins/drone-plugin-lib/drone"
 	"github.com/joho/godotenv"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
-
-	docker "github.com/drone-plugins/drone-docker"
-	"github.com/drone-plugins/drone-plugin-lib/drone"
 )
 
 var (
 	version = "unknown"
-	charset = []byte("abcdefghijklmnopqrstuvwxyz")
 )
 
 func main() {
@@ -388,17 +386,7 @@ func run(c *cli.Context) error {
 }
 
 func generateTempTag() string {
-	tagLength := 8
-	return randomString(tagLength)
-}
-
-func randomString(n int) string {
-	rand.Seed(time.Now().UTC().UnixNano())
-	b := make([]byte, n)
-	for i := range b {
-		b[i] = charset[rand.Intn(len(charset))]
-	}
-	return string(b)
+	return strings.ToLower(uniuri.New())
 }
 
 func GetExecCmd() string {

--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -6,11 +6,12 @@ import (
 	"strings"
 
 	"github.com/dchest/uniuri"
-	docker "github.com/drone-plugins/drone-docker"
-	"github.com/drone-plugins/drone-plugin-lib/drone"
 	"github.com/joho/godotenv"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
+
+	docker "github.com/drone-plugins/drone-docker"
+	"github.com/drone-plugins/drone-plugin-lib/drone"
 )
 
 var (

--- a/docker.go
+++ b/docker.go
@@ -583,14 +583,3 @@ func getDigest(buildName string) (string, error) {
 	}
 	return "", errors.New("unable to fetch digest")
 }
-
-func getUniqueBuildName(repo, buildName string) string {
-	var shortenCommitSHA string
-	if len(buildName) <= 8 {
-		shortenCommitSHA = buildName
-	} else {
-		shortenCommitSHA = buildName[:8]
-	}
-	imageName := repo[strings.LastIndex(repo, "/")+1:]
-	return fmt.Sprintf("%s-%s", imageName, shortenCommitSHA)
-}

--- a/docker.go
+++ b/docker.go
@@ -225,12 +225,12 @@ func (p Plugin) Exec() error {
 	}
 
 	// output the adaptive card
-	if err := p.writeCard(); err != nil {
+	if err := p.writeCard(buildName); err != nil {
 		fmt.Printf("Could not create adaptive card. %s\n", err)
 	}
 
 	if p.ArtifactFile != "" {
-		if digest, err := getDigest(p.Build.Name); err == nil {
+		if digest, err := getDigest(buildName); err == nil {
 			if err = drone.WritePluginArtifactFile(p.Daemon.RegistryType, p.ArtifactFile, p.Daemon.Registry, p.Build.Repo, digest, p.Build.Tags); err != nil {
 				fmt.Printf("failed to write plugin artifact file at path: %s with error: %s\n", p.ArtifactFile, err)
 			}
@@ -244,8 +244,8 @@ func (p Plugin) Exec() error {
 		// clear the slice
 		cmds = nil
 
-		cmds = append(cmds, commandRmi(p.Build.Name)) // docker rmi
-		cmds = append(cmds, commandPrune())           // docker system prune -f
+		cmds = append(cmds, commandRmi(buildName)) // docker rmi
+		cmds = append(cmds, commandPrune())        // docker system prune -f
 
 		for _, cmd := range cmds {
 			cmd.Stdout = os.Stdout

--- a/docker_test.go
+++ b/docker_test.go
@@ -16,6 +16,7 @@ func TestCommandBuild(t *testing.T) {
 			name: "secret from env var",
 			build: Build{
 				Name:       "plugins/drone-docker:latest",
+				TempTag:    "abcdefgh",
 				Dockerfile: "Dockerfile",
 				Context:    ".",
 				SecretEnvs: []string{
@@ -29,7 +30,7 @@ func TestCommandBuild(t *testing.T) {
 				"-f",
 				"Dockerfile",
 				"-t",
-				"plugins/drone-docker:latest",
+				"abcdefgh",
 				".",
 				"--secret id=foo_secret,env=FOO_SECRET_ENV_VAR",
 			),
@@ -38,6 +39,7 @@ func TestCommandBuild(t *testing.T) {
 			name: "secret from file",
 			build: Build{
 				Name:       "plugins/drone-docker:latest",
+				TempTag:    "abcdefgh",
 				Dockerfile: "Dockerfile",
 				Context:    ".",
 				SecretFiles: []string{
@@ -51,7 +53,7 @@ func TestCommandBuild(t *testing.T) {
 				"-f",
 				"Dockerfile",
 				"-t",
-				"plugins/drone-docker:latest",
+				"abcdefgh",
 				".",
 				"--secret id=foo_secret,src=/path/to/foo_secret",
 			),
@@ -60,6 +62,7 @@ func TestCommandBuild(t *testing.T) {
 			name: "multiple mixed secrets",
 			build: Build{
 				Name:       "plugins/drone-docker:latest",
+				TempTag:    "abcdefgh",
 				Dockerfile: "Dockerfile",
 				Context:    ".",
 				SecretEnvs: []string{
@@ -78,7 +81,7 @@ func TestCommandBuild(t *testing.T) {
 				"-f",
 				"Dockerfile",
 				"-t",
-				"plugins/drone-docker:latest",
+				"abcdefgh",
 				".",
 				"--secret id=foo_secret,env=FOO_SECRET_ENV_VAR",
 				"--secret id=bar_secret,env=BAR_SECRET_ENV_VAR",
@@ -90,6 +93,7 @@ func TestCommandBuild(t *testing.T) {
 			name: "invalid mixed secrets",
 			build: Build{
 				Name:       "plugins/drone-docker:latest",
+				TempTag:    "abcdefgh",
 				Dockerfile: "Dockerfile",
 				Context:    ".",
 				SecretEnvs: []string{
@@ -110,7 +114,7 @@ func TestCommandBuild(t *testing.T) {
 				"-f",
 				"Dockerfile",
 				"-t",
-				"plugins/drone-docker:latest",
+				"abcdefgh",
 				".",
 			),
 		},
@@ -118,6 +122,7 @@ func TestCommandBuild(t *testing.T) {
 			name: "platform argument",
 			build: Build{
 				Name:       "plugins/drone-docker:latest",
+				TempTag:    "abcdefgh",
 				Dockerfile: "Dockerfile",
 				Context:    ".",
 				Platform:   "test/platform",
@@ -129,7 +134,7 @@ func TestCommandBuild(t *testing.T) {
 				"-f",
 				"Dockerfile",
 				"-t",
-				"plugins/drone-docker:latest",
+				"abcdefgh",
 				".",
 				"--platform",
 				"test/platform",
@@ -139,6 +144,7 @@ func TestCommandBuild(t *testing.T) {
 			name: "ssh agent",
 			build: Build{
 				Name:       "plugins/drone-docker:latest",
+				TempTag:    "abcdefgh",
 				Dockerfile: "Dockerfile",
 				Context:    ".",
 				SSHKeyPath: "id_rsa=/root/.ssh/id_rsa",
@@ -150,7 +156,7 @@ func TestCommandBuild(t *testing.T) {
 				"-f",
 				"Dockerfile",
 				"-t",
-				"plugins/drone-docker:latest",
+				"abcdefgh",
 				".",
 				"--ssh id_rsa=/root/.ssh/id_rsa",
 			),
@@ -161,7 +167,7 @@ func TestCommandBuild(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := commandBuild(tc.build, "plugins/drone-docker:latest")
+			cmd := commandBuild(tc.build)
 
 			if !reflect.DeepEqual(cmd.String(), tc.want.String()) {
 				t.Errorf("Got cmd %v, want %v", cmd, tc.want)

--- a/docker_test.go
+++ b/docker_test.go
@@ -161,7 +161,7 @@ func TestCommandBuild(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := commandBuild(tc.build)
+			cmd := commandBuild(tc.build, "plugins/drone-docker:latest")
 
 			if !reflect.DeepEqual(cmd.String(), tc.want.String()) {
 				t.Errorf("Got cmd %v, want %v", cmd, tc.want)

--- a/docker_test.go
+++ b/docker_test.go
@@ -1,12 +1,15 @@
 package docker
 
 import (
+	"github.com/dchest/uniuri"
 	"os/exec"
 	"reflect"
+	"strings"
 	"testing"
 )
 
 func TestCommandBuild(t *testing.T) {
+	tempTag := strings.ToLower(uniuri.New())
 	tcs := []struct {
 		name  string
 		build Build
@@ -16,7 +19,7 @@ func TestCommandBuild(t *testing.T) {
 			name: "secret from env var",
 			build: Build{
 				Name:       "plugins/drone-docker:latest",
-				TempTag:    "abcdefgh",
+				TempTag:    tempTag,
 				Dockerfile: "Dockerfile",
 				Context:    ".",
 				SecretEnvs: []string{
@@ -30,7 +33,7 @@ func TestCommandBuild(t *testing.T) {
 				"-f",
 				"Dockerfile",
 				"-t",
-				"abcdefgh",
+				tempTag,
 				".",
 				"--secret id=foo_secret,env=FOO_SECRET_ENV_VAR",
 			),
@@ -39,7 +42,7 @@ func TestCommandBuild(t *testing.T) {
 			name: "secret from file",
 			build: Build{
 				Name:       "plugins/drone-docker:latest",
-				TempTag:    "abcdefgh",
+				TempTag:    tempTag,
 				Dockerfile: "Dockerfile",
 				Context:    ".",
 				SecretFiles: []string{
@@ -53,7 +56,7 @@ func TestCommandBuild(t *testing.T) {
 				"-f",
 				"Dockerfile",
 				"-t",
-				"abcdefgh",
+				tempTag,
 				".",
 				"--secret id=foo_secret,src=/path/to/foo_secret",
 			),
@@ -62,7 +65,7 @@ func TestCommandBuild(t *testing.T) {
 			name: "multiple mixed secrets",
 			build: Build{
 				Name:       "plugins/drone-docker:latest",
-				TempTag:    "abcdefgh",
+				TempTag:    tempTag,
 				Dockerfile: "Dockerfile",
 				Context:    ".",
 				SecretEnvs: []string{
@@ -81,7 +84,7 @@ func TestCommandBuild(t *testing.T) {
 				"-f",
 				"Dockerfile",
 				"-t",
-				"abcdefgh",
+				tempTag,
 				".",
 				"--secret id=foo_secret,env=FOO_SECRET_ENV_VAR",
 				"--secret id=bar_secret,env=BAR_SECRET_ENV_VAR",
@@ -93,7 +96,7 @@ func TestCommandBuild(t *testing.T) {
 			name: "invalid mixed secrets",
 			build: Build{
 				Name:       "plugins/drone-docker:latest",
-				TempTag:    "abcdefgh",
+				TempTag:    tempTag,
 				Dockerfile: "Dockerfile",
 				Context:    ".",
 				SecretEnvs: []string{
@@ -114,7 +117,7 @@ func TestCommandBuild(t *testing.T) {
 				"-f",
 				"Dockerfile",
 				"-t",
-				"abcdefgh",
+				tempTag,
 				".",
 			),
 		},
@@ -122,7 +125,7 @@ func TestCommandBuild(t *testing.T) {
 			name: "platform argument",
 			build: Build{
 				Name:       "plugins/drone-docker:latest",
-				TempTag:    "abcdefgh",
+				TempTag:    tempTag,
 				Dockerfile: "Dockerfile",
 				Context:    ".",
 				Platform:   "test/platform",
@@ -134,7 +137,7 @@ func TestCommandBuild(t *testing.T) {
 				"-f",
 				"Dockerfile",
 				"-t",
-				"abcdefgh",
+				tempTag,
 				".",
 				"--platform",
 				"test/platform",
@@ -144,7 +147,7 @@ func TestCommandBuild(t *testing.T) {
 			name: "ssh agent",
 			build: Build{
 				Name:       "plugins/drone-docker:latest",
-				TempTag:    "abcdefgh",
+				TempTag:    tempTag,
 				Dockerfile: "Dockerfile",
 				Context:    ".",
 				SSHKeyPath: "id_rsa=/root/.ssh/id_rsa",
@@ -156,7 +159,7 @@ func TestCommandBuild(t *testing.T) {
 				"-f",
 				"Dockerfile",
 				"-t",
-				"abcdefgh",
+				tempTag,
 				".",
 				"--ssh id_rsa=/root/.ssh/id_rsa",
 			),

--- a/docker_test.go
+++ b/docker_test.go
@@ -1,11 +1,12 @@
 package docker
 
 import (
-	"github.com/dchest/uniuri"
 	"os/exec"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/dchest/uniuri"
 )
 
 func TestCommandBuild(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
+	github.com/dchest/uniuri v1.2.0 // indirect
 	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	golang.org/x/sys v0.0.0-20220731174439-a90be440212d // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dchest/uniuri v1.2.0 h1:koIcOUdrTIivZgSLhHQvKgqdWZq5d7KdMEWF1Ud6+5g=
+github.com/dchest/uniuri v1.2.0/go.mod h1:fSzm4SLHzNZvWLvWJew423PhAzkpNQYq+uNLq4kxhkY=
 github.com/drone-plugins/drone-plugin-lib v0.4.1 h1:47rZlmcMpr1hSp+6Gl+1Z4t+efi/gMQU3lxukC1Yg64=
 github.com/drone-plugins/drone-plugin-lib v0.4.1/go.mod h1:KwCu92jFjHV3xv2hu5Qg/8zBNvGwbhoJDQw/EwnTvoM=
 github.com/drone/drone-go v1.7.1 h1:ZX+3Rs8YHUSUQ5mkuMLmm1zr1ttiiE2YGNxF3AnyDKw=


### PR DESCRIPTION
Bug:

Created 2 dockerfiles where we set the below environment variables and built them in parallel:
`testimg:1.0` : `ENV GOPATH=$HOME/go`
`testimg2:2.0` : `ENV GOPATH=$HOME/go2`

Parallel Step 1:
<img width="698" alt="image" src="https://github.com/drone-plugins/drone-docker/assets/103484777/594ba392-f661-4363-8585-52d6cf0db7aa">

Parallel Step 2:
<img width="705" alt="image" src="https://github.com/drone-plugins/drone-docker/assets/103484777/87339e71-be54-45f3-844c-2bede29ad32a">

Reproduced the bug where both testimg and testimg2 were the same (since the environment variable set was the same) after they were built. Ideally the should be different:
Commands used:
`testimg:1.0`:
`docker run --name=testcontainer1 rutvijspit/testimg:1.0`
`docker exec testcontainer1 sh -c /usr/bin/env | grep GOPATH`

`testimg2:2.0`:
`docker run --name=testcontainer2 rutvijspit/testimg2:2.0`
`docker exec testcontainer2 sh -c /usr/bin/env | grep GOPATH`

<img width="340" alt="image" src="https://github.com/drone-plugins/drone-docker/assets/103484777/30621924-7ff0-4e88-aad4-84ef05030c08">

After the fix:

Parallel Step 1:
![image](https://github.com/drone-plugins/drone-docker/assets/103484777/c24b1032-4146-4241-b8e3-35065d527128)

Parallel Step 2:
![image](https://github.com/drone-plugins/drone-docker/assets/103484777/4a36374f-3945-4f58-9770-c755852b3de2)

Verification that different environement variable is set:
![image](https://github.com/drone-plugins/drone-docker/assets/103484777/27e18604-bc87-4616-bd64-36a650b85e8f)
