### PR TITLE
update docker linux amd64/arm64 to 20.10.24

### DIFF
--- a/docker/docker/Dockerfile.linux.amd64
+++ b/docker/docker/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM docker:20.10.14-dind
+FROM docker:20.10.24-dind
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 

--- a/docker/docker/Dockerfile.linux.arm64
+++ b/docker/docker/Dockerfile.linux.arm64
@@ -1,4 +1,4 @@
-FROM arm64v8/docker:20.10.14-dind
+FROM arm64v8/docker:20.10.24-dind
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 


### PR DESCRIPTION
Straight forward update to the latest 2.10.x release, which is 20.10.24 by now.

I personally have a minor build issue that results in unnecessarily larger layers using an older version of the _Docker_ engine. Seems to be resolved with current releases, so I would appreciate to have this resolved in my Drone pipelines as well.