### PR TITLE
Update docker location in getDigest

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -572,7 +572,7 @@ func GetDroneDockerExecCmd() string {
 }
 
 func getDigest(buildName string) (string, error) {
-	cmd := exec.Command("docker", "inspect", "--format='{{index .RepoDigests 0}}'", buildName)
+	cmd := exec.Command(dockerExe, "inspect", "--format='{{index .RepoDigests 0}}'", buildName)
 	output, err := cmd.Output()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
On Windows the digest isn't generated because `docker` isn't on the path. Use the value of `dockerExe` here.


