### PR TITLE
Don't run `prune` during cleanup since it can lead to parallel builds…

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -244,13 +244,22 @@ func (p Plugin) Exec() error {
 		// clear the slice
 		cmds = nil
 
+		// Remove all images that were created.
 		cmds = append(cmds, commandRmi(p.Build.TempTag)) // docker rmi
-		cmds = append(cmds, commandPrune())              // docker system prune -f
+		for _, tag := range p.Build.Tags {
+			cmds = append(cmds, commandRmi(tag)) // docker rmi
+		}
 
 		for _, cmd := range cmds {
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
 			trace(cmd)
+
+			err := cmd.Run()
+
+			if err != nil {
+				fmt.Printf("Could not remove image %s. Ignoring...\n", cmd.Args[2])
+			}
 		}
 	}
 


### PR DESCRIPTION
#407 