### PR TITLE
Remove .git suffix from opencontainer source label

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -387,7 +387,7 @@ func commandBuild(build Build) *exec.Cmd {
 		labelSchema := []string{
 			fmt.Sprintf("created=%s", time.Now().Format(time.RFC3339)),
 			fmt.Sprintf("revision=%s", build.Name),
-			fmt.Sprintf("source=%s", build.Remote),
+			fmt.Sprintf("source=%s", strings.TrimSuffix(build.Remote, ".git")),
 			fmt.Sprintf("url=%s", build.Link),
 		}
 		labelPrefix := "org.opencontainers.image"


### PR DESCRIPTION
The `org.opencontainers.image.source` label currently look like this: `https://github.com/octocat/hello-world.git`. Looking through GitHub however, I believe that the .git suffix should not be there. Furthermore, GitHub packages support automatically linking an uploaded container image to the source repository using labels, but this feature does not work with the extra .git suffix. This pull request therefore removes the .git suffix from the label.

References:
https://github.com/search?q=org.opencontainers.image.source&type=code
https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#labelling-container-images