### PR TITLE
Master

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -272,9 +272,6 @@ func (p Plugin) Exec() error {
 
 // helper function to create the docker login command.
 func commandLogin(login Login) *exec.Cmd {
-	if login.Email != "" {
-		return commandLoginEmail(login)
-	}
 	return exec.Command(
 		dockerExe, "login",
 		"-u", login.Username,

--- a/docker.go
+++ b/docker.go
@@ -300,16 +300,6 @@ func commandPull(repo string) *exec.Cmd {
 	return exec.Command(dockerExe, "pull", repo)
 }
 
-func commandLoginEmail(login Login) *exec.Cmd {
-	return exec.Command(
-		dockerExe, "login",
-		"-u", login.Username,
-		"-p", login.Password,
-		"-e", login.Email,
-		login.Registry,
-	)
-}
-
 // helper function to create the docker info command.
 func commandVersion() *exec.Cmd {
 	return exec.Command(dockerExe, "version")


### PR DESCRIPTION

For latest docker, `docker login` has no params `-e`, if added it, will show like following
```
unknown shorthand flag: 'e' in -e
See 'docker login --help'.
```