### PR TITLE
update docker linux amd64/arm64 to 24.0.7

### DIFF
--- a/docker/docker/Dockerfile.linux.amd64
+++ b/docker/docker/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM docker:20.10.14-dind
+FROM docker:24.0.7-dind
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 

--- a/docker/docker/Dockerfile.linux.arm64
+++ b/docker/docker/Dockerfile.linux.arm64
@@ -1,4 +1,4 @@
-FROM arm64v8/docker:20.10.14-dind
+FROM arm64v8/docker:24.0.7-dind
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 


### PR DESCRIPTION
Update the base image to the latest docker release, which is 24.0.7.

This apparently fixes the kernel issues on Alpine 3.19 as in https://github.com/drone-plugins/drone-docker/issues/414.