### PR TITLE
Change docker login method, from config writing to login func

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -158,34 +158,33 @@ func (p Plugin) Exec() error {
 		os.MkdirAll(dockerHome, 0600)
 
 		path := filepath.Join(dockerHome, "config.json")
-		file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+		err := os.WriteFile(path, []byte(p.Login.Config), 0600)
 		if err != nil {
 			return fmt.Errorf("Error writing config.json: %s", err)
 		}
-		err = os.WriteFile(path, []byte(p.Login.Config), 0600)
-		if err != nil {
-			return fmt.Errorf("Error writing config.json: %s", err)
-		}
-		file.Close()
 	}
 
 	// add base image docker credentials to the existing config file, else create new
+	// instead of writing to config file directly, using docker's login func
+	// is better to integrate with various credential helpers,
+	//	it also handles different registry specific logic in a better way,
+	//	as opposed to config write where different registries need to be addressed differently.
+	//	It handles any changes in the authentication process across different Docker versions.
+
 	if p.BaseImagePassword != "" {
-		json, err := setDockerAuth(p.Login.Username, p.Login.Password, p.Login.Registry,
-			p.BaseImageUsername, p.BaseImagePassword, p.BaseImageRegistry)
+		var baseConnectorLogin Login
+		baseConnectorLogin.Registry = p.BaseImageRegistry
+		baseConnectorLogin.Username = p.BaseImageUsername
+		baseConnectorLogin.Password = p.BaseImagePassword
+
+		cmd := commandLogin(baseConnectorLogin)
+
+		raw, err := cmd.CombinedOutput()
 		if err != nil {
-			return fmt.Errorf("Failed to set authentication in docker config %s", err)
-		}
-		os.MkdirAll(dockerHome, 0600)
-		path := filepath.Join(dockerHome, "config.json")
-		file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
-		if err != nil {
-			return fmt.Errorf("Error opening config.json: %s", err)
-		}
-		defer file.Close()
-		_, err = file.Write(json)
-		if err != nil {
-			return fmt.Errorf("Error writing config.json: %s", err)
+			out := string(raw)
+			out = strings.Replace(out, "WARNING! Using --password via the CLI is insecure. Use --password-stdin.", "", -1)
+			fmt.Println(out)
+			return fmt.Errorf("Error authenticating base connector: exit status 1")
 		}
 	}
 

--- a/docker.go
+++ b/docker.go
@@ -164,7 +164,6 @@ func (p Plugin) Exec() error {
 		}
 	}
 
-	// add base image docker credentials to the existing config file, else create new
 	// instead of writing to config file directly, using docker's login func
 	// is better to integrate with various credential helpers,
 	//	it also handles different registry specific logic in a better way,


### PR DESCRIPTION
This upgrade includes changes in base buildx version:

Changed the login to docker login command instead of using the Config struct for OIDC changes.
Made the decision to use login instead of writing file directly.
Why the change was made - The login function integrates with various credential helpers, it also handles different registry specific logic in a better way, as opposed to config write where different registries need to be addressed differently.
It handles any changes in the authentication process across different Docker versions.

https://docs.google.com/document/d/153BXzvNWUZ-XD2qOIuPDQ3XWVSI89tR0uBppLNS-F-4/edit