### PR TITLE
ECR: Add ability to set tag mutability on repo creation

### DIFF
--- a/cmd/drone-ecr/main.go
+++ b/cmd/drone-ecr/main.go
@@ -42,6 +42,7 @@ func main() {
 		assumeRole       = getenv("PLUGIN_ASSUME_ROLE")
 		externalId       = getenv("PLUGIN_EXTERNAL_ID")
 		scanOnPush       = parseBoolOrDefault(false, getenv("PLUGIN_SCAN_ON_PUSH"))
+		tagImmutable     = parseBoolOrDefault(false, getenv("PLUGIN_TAG_IMMUTABLE"))
 		idToken          = os.Getenv("PLUGIN_OIDC_TOKEN_ID")
 	)
 
@@ -78,13 +79,17 @@ func main() {
 	}
 
 	if create {
-		err = ensureRepoExists(svc, trimHostname(repo, registry), scanOnPush)
+		err = ensureRepoExists(svc, trimHostname(repo, registry), scanOnPush, getTagImmutableString(tagImmutable))
 		if err != nil {
 			log.Fatal(fmt.Sprintf("error creating ECR repo: %v", err))
 		}
 		err = updateImageScannningConfig(svc, trimHostname(repo, registry), scanOnPush)
 		if err != nil {
 			log.Fatal(fmt.Sprintf("error updating scan on push for ECR repo: %v", err))
+		}
+		err = updateImageTagMutabilityConfig(svc, trimHostname(repo, registry), getTagImmutableString(tagImmutable))
+		if err != nil {
+			log.Fatal(fmt.Sprintf("error updating tag mutability for ECR repo: %v", err))
 		}
 	}
 
@@ -129,10 +134,11 @@ func trimHostname(repo, registry string) string {
 	return repo
 }
 
-func ensureRepoExists(svc *ecr.ECR, name string, scanOnPush bool) (err error) {
+func ensureRepoExists(svc *ecr.ECR, name string, scanOnPush bool, tagMutabilityOption string) (err error) {
 	input := &ecr.CreateRepositoryInput{}
 	input.SetRepositoryName(name)
 	input.SetImageScanningConfiguration(&ecr.ImageScanningConfiguration{ScanOnPush: &scanOnPush})
+	input.SetImageTagMutability(tagMutabilityOption)
 	_, err = svc.CreateRepository(input)
 	if err != nil {
 		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == ecr.ErrCodeRepositoryAlreadyExistsException {
@@ -149,6 +155,15 @@ func updateImageScannningConfig(svc *ecr.ECR, name string, scanOnPush bool) (err
 	input.SetRepositoryName(name)
 	input.SetImageScanningConfiguration(&ecr.ImageScanningConfiguration{ScanOnPush: &scanOnPush})
 	_, err = svc.PutImageScanningConfiguration(input)
+
+	return err
+}
+
+func updateImageTagMutabilityConfig(svc *ecr.ECR, name string, tagMutabilityOption string) (err error) {
+	input := &ecr.PutImageTagMutabilityInput{}
+	input.SetRepositoryName(name)
+	input.SetImageTagMutability(tagMutabilityOption)
+	_, err = svc.PutImageTagMutability(input)
 
 	return err
 }
@@ -202,6 +217,14 @@ func parseBoolOrDefault(defaultValue bool, s string) (result bool) {
 	}
 
 	return
+}
+
+func getTagImmutableString(tagImmutable bool) string {
+	immutableTagInput := ecr.ImageTagMutabilityMutable
+	if tagImmutable {
+		immutableTagInput = ecr.ImageTagMutabilityImmutable
+	}
+	return immutableTagInput
 }
 
 func getenv(key ...string) (s string) {

--- a/cmd/drone-ecr/main.go
+++ b/cmd/drone-ecr/main.go
@@ -79,7 +79,7 @@ func main() {
 	}
 
 	if create {
-		err = ensureRepoExists(svc, trimHostname(repo, registry), scanOnPush, getTagImmutableString(tagImmutable))
+		err = ensureRepoExists(svc, trimHostname(repo, registry), scanOnPush, getTagMutabilityString(tagImmutable))
 		if err != nil {
 			log.Fatal(fmt.Sprintf("error creating ECR repo: %v", err))
 		}
@@ -87,7 +87,7 @@ func main() {
 		if err != nil {
 			log.Fatal(fmt.Sprintf("error updating scan on push for ECR repo: %v", err))
 		}
-		err = updateImageTagMutabilityConfig(svc, trimHostname(repo, registry), getTagImmutableString(tagImmutable))
+		err = updateImageTagMutabilityConfig(svc, trimHostname(repo, registry), getTagMutabilityString(tagImmutable))
 		if err != nil {
 			log.Fatal(fmt.Sprintf("error updating tag mutability for ECR repo: %v", err))
 		}
@@ -219,7 +219,7 @@ func parseBoolOrDefault(defaultValue bool, s string) (result bool) {
 	return
 }
 
-func getTagImmutableString(tagImmutable bool) string {
+func getTagMutabilityString(tagImmutable bool) string {
 	immutableTagInput := ecr.ImageTagMutabilityMutable
 	if tagImmutable {
 		immutableTagInput = ecr.ImageTagMutabilityImmutable

--- a/cmd/drone-ecr/main_test.go
+++ b/cmd/drone-ecr/main_test.go
@@ -1,6 +1,10 @@
 package main
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ecr"
+)
 
 func TestTrimHostname(t *testing.T) {
 	registry := "000000000000.dkr.ecr.us-east-1.amazonaws.com"
@@ -16,5 +20,33 @@ func TestTrimHostname(t *testing.T) {
 		if splitName != name {
 			t.Errorf("%s is not equal to %s.", splitName, name)
 		}
+	}
+}
+
+func TestGetTagImmutableString(t *testing.T) {
+	testCases := []struct {
+		name         string
+		tagImmutable bool
+		expected     string
+	}{
+		{
+			name:         "mutable",
+			tagImmutable: false,
+			expected:     ecr.ImageTagMutabilityMutable,
+		},
+		{
+			name:         "immutable",
+			tagImmutable: true,
+			expected:     ecr.ImageTagMutabilityImmutable,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := getTagImmutableString(tc.tagImmutable)
+			if actual != tc.expected {
+				t.Errorf("expected: %s, actual: %s", tc.expected, actual)
+			}
+		})
 	}
 }

--- a/cmd/drone-ecr/main_test.go
+++ b/cmd/drone-ecr/main_test.go
@@ -23,7 +23,7 @@ func TestTrimHostname(t *testing.T) {
 	}
 }
 
-func TestGetTagImmutableString(t *testing.T) {
+func TestGetTagMutabilityString(t *testing.T) {
 	testCases := []struct {
 		name         string
 		tagImmutable bool
@@ -43,7 +43,7 @@ func TestGetTagImmutableString(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := getTagImmutableString(tc.tagImmutable)
+			actual := getTagMutabilityString(tc.tagImmutable)
 			if actual != tc.expected {
 				t.Errorf("expected: %s, actual: %s", tc.expected, actual)
 			}


### PR DESCRIPTION
Hi!

We have a use-case where we want to force our ECR repos to have tag mutability set to `IMMUTABLE`. Since we have repo's with `create_repository` set to true, we only want to modify ones that are managed by the drone plugin.

AWS ECR tag mutability is a `string` of `MUTABLE` or `IMMUTABLE`. To simplify usage, I decided to go with a boolean to avoid typos on the plugin usage side. By default, `tag_immutable` is `false`, thus keeping existing behavior. Depending on the boolean, the code will use the provided SDK constants for `MUTABLE` and `IMMUTABLE`

usage example:
```
steps:
  - name: push-image
    image: plugins/ecr
    settings:
      ...
      create_repository: true
      tag_immutable: true
```