### PR TITLE
Do not pre-pull cache images

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -230,11 +230,6 @@ func (p Plugin) Exec() error {
 	cmds = append(cmds, commandVersion()) // docker version
 	cmds = append(cmds, commandInfo())    // docker info
 
-	// pre-pull cache images
-	for _, img := range p.Build.CacheFrom {
-		cmds = append(cmds, commandPull(img))
-	}
-
 	// setup for using ssh agent (https://docs.docker.com/develop/develop-images/build_enhancements/#using-ssh-to-access-private-data-in-builds)
 	if p.Build.SSHAgentKey != "" {
 		var sshErr error
@@ -361,10 +356,6 @@ func commandLoginAccessToken(login Login, accessToken string) *exec.Cmd {
 // helper to check if args match "docker pull <image>"
 func isCommandPull(args []string) bool {
 	return len(args) > 2 && args[1] == "pull"
-}
-
-func commandPull(repo string) *exec.Cmd {
-	return exec.Command(dockerExe, "pull", repo)
 }
 
 func commandLoginEmail(login Login) *exec.Cmd {


### PR DESCRIPTION
Since 20.18.6 / 2140a2be40e8a5511051ffb38974ef83064b49a6 / #462, buildkit is always enabled.

Therefore, there is no need anymore to pre-pull the cached images, `--cache-from` will cause buildkit to pull as needed.

This is a slimmed down alternative to #360.