### PR TITLE
Add support for max layer caching in build

### DIFF
--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -183,6 +183,11 @@ func main() {
 			Usage:  "images to consider as cache sources",
 			EnvVar: "PLUGIN_CACHE_FROM",
 		},
+		cli.StringFlag{
+			Name:   "cache-to",
+			Usage:  "images to consider as cache stores",
+			EnvVar: "PLUGIN_CACHE_TO",
+		},
 		cli.BoolFlag{
 			Name:   "squash",
 			Usage:  "squash the layers at build time",
@@ -370,6 +375,7 @@ func run(c *cli.Context) error {
 			Squash:              c.Bool("squash"),
 			Pull:                c.BoolT("pull-image"),
 			CacheFrom:           c.StringSlice("cache-from"),
+			CacheTo:             c.String("cache-to"),
 			Compress:            c.Bool("compress"),
 			Repo:                c.String("repo"),
 			Labels:              c.StringSlice("custom-labels"),

--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -10,8 +10,9 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli"
 
-	docker "github.com/drone-plugins/drone-docker"
 	"github.com/drone-plugins/drone-plugin-lib/drone"
+
+	docker "github.com/drone-plugins/drone-docker"
 )
 
 var (
@@ -101,6 +102,11 @@ func main() {
 			Name:   "daemon.experimental",
 			Usage:  "docker daemon Experimental mode",
 			EnvVar: "PLUGIN_EXPERIMENTAL",
+		},
+		cli.BoolFlag{
+			Name:   "daemon.containerd-image-store",
+			Usage:  "docker daemon containerd image store",
+			EnvVar: "PLUGIN_CONTAINERD_IMAGE_STORE",
 		},
 		cli.BoolFlag{
 			Name:   "daemon.debug",
@@ -380,20 +386,21 @@ func run(c *cli.Context) error {
 			SSHAgentKey:         c.String("ssh-agent-key"),
 		},
 		Daemon: docker.Daemon{
-			Registry:      c.String("docker.registry"),
-			Mirror:        c.String("daemon.mirror"),
-			StorageDriver: c.String("daemon.storage-driver"),
-			StoragePath:   c.String("daemon.storage-path"),
-			Insecure:      c.Bool("daemon.insecure"),
-			Disabled:      c.Bool("daemon.off"),
-			IPv6:          c.Bool("daemon.ipv6"),
-			Debug:         c.Bool("daemon.debug"),
-			Bip:           c.String("daemon.bip"),
-			DNS:           c.StringSlice("daemon.dns"),
-			DNSSearch:     c.StringSlice("daemon.dns-search"),
-			MTU:           c.String("daemon.mtu"),
-			Experimental:  c.Bool("daemon.experimental"),
-			RegistryType:  registryType,
+			Registry:                    c.String("docker.registry"),
+			Mirror:                      c.String("daemon.mirror"),
+			StorageDriver:               c.String("daemon.storage-driver"),
+			StoragePath:                 c.String("daemon.storage-path"),
+			Insecure:                    c.Bool("daemon.insecure"),
+			Disabled:                    c.Bool("daemon.off"),
+			IPv6:                        c.Bool("daemon.ipv6"),
+			Debug:                       c.Bool("daemon.debug"),
+			Bip:                         c.String("daemon.bip"),
+			DNS:                         c.StringSlice("daemon.dns"),
+			DNSSearch:                   c.StringSlice("daemon.dns-search"),
+			MTU:                         c.String("daemon.mtu"),
+			Experimental:                c.Bool("daemon.experimental"),
+			RegistryType:                registryType,
+			ContainerdImageStoreEnabled: c.Bool("daemon.containerd-image-store"),
 		},
 		BaseImageRegistry: c.String("docker.baseimageregistry"),
 		BaseImageUsername: c.String("docker.baseimageusername"),

--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -184,6 +184,11 @@ func main() {
 			EnvVar: "PLUGIN_CACHE_FROM",
 		},
 		cli.StringFlag{
+			Name:   "cache-from-explicit",
+			Usage:  "image to consider as cache source fully specified",
+			EnvVar: "PLUGIN_CACHE_FROM_EXPLICIT",
+		},
+		cli.StringFlag{
 			Name:   "cache-to",
 			Usage:  "images to consider as cache stores",
 			EnvVar: "PLUGIN_CACHE_TO",

--- a/docker.go
+++ b/docker.go
@@ -61,6 +61,7 @@ type (
 		Squash              bool     // Docker build squash
 		Pull                bool     // Docker build pull
 		CacheFrom           []string // Docker build cache-from
+		CacheFromExplicit   string   // Docker build cache-from with comma support
 		CacheTo             string   // Docker build cache-to
 		Compress            bool     // Docker build compress
 		Repo                string   // Docker build repository
@@ -414,6 +415,9 @@ func commandBuild(build Build) *exec.Cmd {
 	}
 	for _, arg := range build.CacheFrom {
 		args = append(args, "--cache-from", arg)
+	}
+	if build.CacheFromExplicit != "" {
+		args = append(args, "--cache-from", build.CacheFromExplicit)
 	}
 	if build.CacheTo != "" {
 		args = append(args, "--cache-to", build.CacheTo)

--- a/docker.go
+++ b/docker.go
@@ -61,6 +61,7 @@ type (
 		Squash              bool     // Docker build squash
 		Pull                bool     // Docker build pull
 		CacheFrom           []string // Docker build cache-from
+		CacheTo             string   // Docker build cache-to
 		Compress            bool     // Docker build compress
 		Repo                string   // Docker build repository
 		LabelSchema         []string // label-schema Label map
@@ -413,6 +414,9 @@ func commandBuild(build Build) *exec.Cmd {
 	}
 	for _, arg := range build.CacheFrom {
 		args = append(args, "--cache-from", arg)
+	}
+	if build.CacheTo != "" {
+		args = append(args, "--cache-to", build.CacheTo)
 	}
 	for _, arg := range build.ArgsEnv {
 		addProxyValue(&build, arg)

--- a/docker.go
+++ b/docker.go
@@ -10,27 +10,29 @@ import (
 	"strings"
 	"time"
 
-	"github.com/drone-plugins/drone-docker/internal/docker"
 	"github.com/drone-plugins/drone-plugin-lib/drone"
+
+	"github.com/drone-plugins/drone-docker/internal/docker"
 )
 
 type (
 	// Daemon defines Docker daemon parameters.
 	Daemon struct {
-		Registry      string             // Docker registry
-		Mirror        string             // Docker registry mirror
-		Insecure      bool               // Docker daemon enable insecure registries
-		StorageDriver string             // Docker daemon storage driver
-		StoragePath   string             // Docker daemon storage path
-		Disabled      bool               // DOcker daemon is disabled (already running)
-		Debug         bool               // Docker daemon started in debug mode
-		Bip           string             // Docker daemon network bridge IP address
-		DNS           []string           // Docker daemon dns server
-		DNSSearch     []string           // Docker daemon dns search domain
-		MTU           string             // Docker daemon mtu setting
-		IPv6          bool               // Docker daemon IPv6 networking
-		Experimental  bool               // Docker daemon enable experimental mode
-		RegistryType  drone.RegistryType // Docker registry type
+		Registry                    string             // Docker registry
+		Mirror                      string             // Docker registry mirror
+		Insecure                    bool               // Docker daemon enable insecure registries
+		StorageDriver               string             // Docker daemon storage driver
+		StoragePath                 string             // Docker daemon storage path
+		Disabled                    bool               // DOcker daemon is disabled (already running)
+		Debug                       bool               // Docker daemon started in debug mode
+		Bip                         string             // Docker daemon network bridge IP address
+		DNS                         []string           // Docker daemon dns server
+		DNSSearch                   []string           // Docker daemon dns search domain
+		MTU                         string             // Docker daemon mtu setting
+		IPv6                        bool               // Docker daemon IPv6 networking
+		Experimental                bool               // Docker daemon enable experimental mode
+		RegistryType                drone.RegistryType // Docker registry type
+		ContainerdImageStoreEnabled bool               // Docker daemon containerd image store enabled
 	}
 
 	// Login defines Docker login parameters.
@@ -592,6 +594,9 @@ func commandDaemon(daemon Daemon) *exec.Cmd {
 	args := []string{
 		"--data-root", daemon.StoragePath,
 		"--host=unix:///var/run/docker.sock",
+	}
+	if daemon.ContainerdImageStoreEnabled {
+		args = append(args, "--feature", "containerd-snapshotter=true")
 	}
 
 	if _, err := os.Stat("/etc/docker/default.json"); err == nil {


### PR DESCRIPTION
With the change to buildkit as the default option, layers which are not required for the final image are not cached.

This PR support caching of all images in a build process, specifically by leveraging the containerd image store and the flag `mode=max` for the cache-to.

It requires:
- addition of a flag to support enabling the containerd image store
- addition of a `CACHE_TO` flag
- addition of a `CACHE_FROM_EXPLICIT` flag which can take an image name of the form `type=registry,ref=<registry>/<cache-image>:<branch>`

