### PR TITLE
[CI-16559]: docker base image up for acr/gcr/gar/ecr

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,7 @@ platform:
 
 steps:
   - name: vet
-    image: golang:1.22.4
+    image: golang:1.23
     commands:
       - go vet ./...
     environment:
@@ -22,7 +22,7 @@ steps:
         path: /go
 
   - name: test
-    image: golang:1.22.4
+    image: golang:1.23
     commands:
       - go test -cover ./...
     environment:
@@ -55,7 +55,7 @@ platform:
 
 steps:
   - name: go build
-    image: golang:1.22.4
+    image: golang:1.23
     environment:
       CGO_ENABLED: 0
     commands:
@@ -162,7 +162,7 @@ platform:
 
 steps:
   - name: go build
-    image: golang:1.22.7
+    image: golang:1.23
     environment:
       CGO_ENABLED: 0
     commands:
@@ -264,7 +264,7 @@ platform:
 
 steps:
   - name: build-push
-    image: golang:1.22.7
+    image: golang:1.23
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_COMMIT_SHA:0:8}" -a -tags netgo -o release/linux/amd64/drone-docker ./cmd/drone-docker'
     environment:
@@ -275,7 +275,7 @@ steps:
           - tag
 
   - name: build-tag
-    image: golang:1.22.7
+    image: golang:1.23
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_TAG##v}" -a -tags netgo -o release/linux/amd64/drone-docker ./cmd/drone-docker'
     environment:
@@ -285,7 +285,7 @@ steps:
         - tag
 
   - name: executable
-    image: golang:1.22.7
+    image: golang:1.23
     commands:
       - ./release/linux/amd64/drone-docker --help
 
@@ -329,7 +329,7 @@ platform:
 
 steps:
   - name: build-push
-    image: golang:1.22.7
+    image: golang:1.23
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_COMMIT_SHA:0:8}" -a -tags netgo -o release/linux/arm64/drone-docker ./cmd/drone-docker'
     environment:
@@ -340,7 +340,7 @@ steps:
           - tag
 
   - name: build-tag
-    image: golang:1.22.7
+    image: golang:1.23
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_TAG##v}" -a -tags netgo -o release/linux/arm64/drone-docker ./cmd/drone-docker'
     environment:
@@ -350,7 +350,7 @@ steps:
         - tag
 
   - name: executable
-    image: golang:1.22.7
+    image: golang:1.23
     commands:
       - ./release/linux/arm64/drone-docker --help
 
@@ -429,7 +429,7 @@ platform:
 
 steps:
   - name: build-push
-    image: golang:1.22.7
+    image: golang:1.23
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_COMMIT_SHA:0:8}" -a -tags netgo -o release/linux/amd64/drone-gcr ./cmd/drone-gcr'
     environment:
@@ -440,7 +440,7 @@ steps:
           - tag
 
   - name: build-tag
-    image: golang:1.22.7
+    image: golang:1.23
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_TAG##v}" -a -tags netgo -o release/linux/amd64/drone-gcr ./cmd/drone-gcr'
     environment:
@@ -488,7 +488,7 @@ platform:
 
 steps:
   - name: build-push
-    image: golang:1.22.7
+    image: golang:1.23
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_COMMIT_SHA:0:8}" -a -tags netgo -o release/linux/arm64/drone-gcr ./cmd/drone-gcr'
     environment:
@@ -499,7 +499,7 @@ steps:
           - tag
 
   - name: build-tag
-    image: golang:1.22.7
+    image: golang:1.23
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_TAG##v}" -a -tags netgo -o release/linux/arm64/drone-gcr ./cmd/drone-gcr'
     environment:
@@ -582,7 +582,7 @@ platform:
 
 steps:
   - name: build-push
-    image: golang:1.22.7
+    image: golang:1.23
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_COMMIT_SHA:0:8}" -a -tags netgo -o release/linux/amd64/drone-gar ./cmd/drone-gar'
     environment:
@@ -593,7 +593,7 @@ steps:
           - tag
 
   - name: build-tag
-    image: golang:1.22.7
+    image: golang:1.23
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_TAG##v}" -a -tags netgo -o release/linux/amd64/drone-gar ./cmd/drone-gar'
     environment:
@@ -641,7 +641,7 @@ platform:
 
 steps:
   - name: build-push
-    image: golang:1.22.7
+    image: golang:1.23
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_COMMIT_SHA:0:8}" -a -tags netgo -o release/linux/arm64/drone-gar ./cmd/drone-gar'
     environment:
@@ -652,7 +652,7 @@ steps:
           - tag
 
   - name: build-tag
-    image: golang:1.22.7
+    image: golang:1.23
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_TAG##v}" -a -tags netgo -o release/linux/arm64/drone-gar ./cmd/drone-gar'
     environment:
@@ -734,7 +734,7 @@ platform:
 
 steps:
   - name: build-push
-    image: golang:1.22.7
+    image: golang:1.23
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_COMMIT_SHA:0:8}" -a -tags netgo -o release/linux/amd64/drone-ecr ./cmd/drone-ecr'
     environment:
@@ -744,7 +744,7 @@ steps:
         exclude:
           - tag
   - name: build-tag
-    image: golang:1.22.7
+    image: golang:1.23
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_TAG##v}" -a -tags netgo -o release/linux/amd64/drone-ecr ./cmd/drone-ecr'
     environment:
@@ -792,7 +792,7 @@ platform:
 
 steps:
   - name: build-push
-    image: golang:1.22.7
+    image: golang:1.23
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_COMMIT_SHA:0:8}" -a -tags netgo -o release/linux/arm64/drone-ecr ./cmd/drone-ecr'
     environment:
@@ -802,7 +802,7 @@ steps:
         exclude:
           - tag
   - name: build-tag
-    image: golang:1.22.7
+    image: golang:1.23
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_TAG##v}" -a -tags netgo -o release/linux/arm64/drone-ecr ./cmd/drone-ecr'
     environment:
@@ -885,7 +885,7 @@ platform:
 
 steps:
   - name: build-push
-    image: golang:1.22.7
+    image: golang:1.23
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_COMMIT_SHA:0:8}" -a -tags netgo -o release/linux/amd64/drone-heroku ./cmd/drone-heroku'
     environment:
@@ -895,7 +895,7 @@ steps:
         exclude:
           - tag
   - name: build-tag
-    image: golang:1.22.7
+    image: golang:1.23
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_TAG##v}" -a -tags netgo -o release/linux/amd64/drone-heroku ./cmd/drone-heroku'
     environment:
@@ -944,7 +944,7 @@ platform:
 
 steps:
   - name: build-push
-    image: golang:1.22.7
+    image: golang:1.23
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_COMMIT_SHA:0:8}" -a -tags netgo -o release/linux/arm64/drone-heroku ./cmd/drone-heroku'
     environment:
@@ -954,7 +954,7 @@ steps:
         exclude:
           - tag
   - name: build-tag
-    image: golang:1.22.7
+    image: golang:1.23
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_TAG##v}" -a -tags netgo -o release/linux/arm64/drone-heroku ./cmd/drone-heroku'
     environment:
@@ -1035,7 +1035,7 @@ platform:
 
 steps:
   - name: build-push
-    image: golang:1.22.7
+    image: golang:1.23
     commands:
       - 'go build -v -ldflags "-X main.build=${DRONE_BUILD_NUMBER}" -a -tags netgo -o release/linux/amd64/drone-acr ./cmd/drone-acr'
     environment:
@@ -1045,7 +1045,7 @@ steps:
         exclude:
           - tag
   - name: build-tag
-    image: golang:1.22.7
+    image: golang:1.23
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_TAG##v} -X main.build=${DRONE_BUILD_NUMBER}" -a -tags netgo -o release/linux/amd64/drone-acr ./cmd/drone-acr'
     environment:
@@ -1093,7 +1093,7 @@ platform:
 
 steps:
   - name: build-push
-    image: golang:1.22.7
+    image: golang:1.23
     commands:
       - 'go build -v -ldflags "-X main.build=${DRONE_BUILD_NUMBER}" -a -tags netgo -o release/linux/arm64/drone-acr ./cmd/drone-acr'
     environment:
@@ -1104,7 +1104,7 @@ steps:
           - tag
 
   - name: build-tag
-    image: golang:1.22.7
+    image: golang:1.23
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_TAG##v} -X main.build=${DRONE_BUILD_NUMBER}" -a -tags netgo -o release/linux/arm64/drone-acr ./cmd/drone-acr'
     environment:

--- a/docker/acr/Dockerfile.linux.amd64
+++ b/docker/acr/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM plugins/docker:linux-amd64
+FROM ebtasamfaridy/plugins-docker:2.1
 
 ADD release/linux/amd64/drone-acr /bin/
 ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh", "/bin/drone-acr"]

--- a/docker/docker/Dockerfile.linux.amd64
+++ b/docker/docker/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM docker:20.10.14-dind
+FROM docker:28.1.1-dind
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 

--- a/docker/ecr/Dockerfile.linux.amd64
+++ b/docker/ecr/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM plugins/docker:linux-amd64
+FROM ebtasamfaridy/plugins-docker:2.1
 
 ADD release/linux/amd64/drone-ecr /bin/
 ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh", "/bin/drone-ecr"]

--- a/docker/gar/Dockerfile.linux.amd64
+++ b/docker/gar/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM plugins/docker:linux-amd64
+FROM ebtasamfaridy/plugins-docker:2.1
 
 ADD release/linux/amd64/drone-gar /bin/
 ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh", "/bin/drone-gar"]

--- a/docker/gcr/Dockerfile.linux.amd64
+++ b/docker/gcr/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM plugins/docker:linux-amd64
+FROM ebtasamfaridy/plugins-docker:2.1
 
 ADD release/linux/amd64/drone-gcr /bin/
 ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh", "/bin/drone-gcr"]


### PR DESCRIPTION
Temp changes to upgrade plugins/docker image to resolve vulnerability
Before:
https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/all/orgs/Security_and_Compliance/projects/ProdSec/pipelines/Ondemand_Vulnerability_Scanner/deployments/y5zvAtMDT4Sd2u9Admu45Q/pipeline?storeType=INLINE

After:
https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/all/orgs/Security_and_Compliance/projects/ProdSec/pipelines/Ondemand_Vulnerability_Scanner/deployments/La_OP5X-Qsq8rnMFiegotw/pipeline