### PR TITLE
feat: [CI-18308]: Add Cosign Image Signing Support

### DIFF
--- a/COSIGN_USAGE.md
+++ b/COSIGN_USAGE.md
@@ -1,0 +1,162 @@
+# Cosign Integration for Drone-Docker
+
+This document describes how to use the cosign container image signing feature in drone-docker.
+
+## Overview
+
+The drone-docker plugin now supports automatic container image signing using cosign after each successful push. This provides cryptographic verification that images haven't been tampered with.
+
+## Environment Variables
+
+The plugin accepts three cosign-related environment variables:
+
+### `PLUGIN_COSIGN_PRIVATE_KEY` (Required for signing)
+- **Description**: Private key for signing (PEM format content or file path)
+- **Format**: Either PEM content or file path to private key
+- **Usage**: Should be provided via secrets
+
+### `PLUGIN_COSIGN_PASSWORD` (Optional)
+- **Description**: Password for encrypted private keys
+- **Usage**: Only needed if your private key is password-protected
+
+### `PLUGIN_COSIGN_PARAMS` (Optional)
+- **Description**: Additional cosign parameters
+- **Examples**: 
+  - `-a build_id=123` (add annotations)
+  - `--tlog-upload=false` (disable transparency log)
+  - `--rekor-url=https://custom-rekor.example.com` (custom rekor instance)
+
+## Usage Examples
+
+### 1. Basic Signing (Drone)
+
+```yaml
+kind: pipeline
+type: docker
+name: default
+
+steps:
+- name: docker
+  image: plugins/docker
+  settings:
+    repo: myregistry/myapp
+    tags: latest
+    cosign_private_key:
+      from_secret: cosign_private_key
+    cosign_password:
+      from_secret: cosign_password
+```
+
+### 2. Advanced Signing with Annotations (Drone)
+
+```yaml
+steps:
+- name: docker
+  image: plugins/docker
+  settings:
+    repo: myregistry/myapp
+    tags: 
+      - latest
+      - ${DRONE_BUILD_NUMBER}
+    cosign_private_key:
+      from_secret: cosign_private_key
+    cosign_params: "-a build_id=${DRONE_BUILD_NUMBER} -a commit_sha=${DRONE_COMMIT_SHA} -a branch=${DRONE_BRANCH}"
+```
+
+### 3. Harness CI/CD Usage
+
+```yaml
+- step:
+    type: Plugin
+    name: Build and Sign
+    identifier: build_and_sign
+    spec:
+      connectorRef: account.harnessImage
+      image: plugins/docker
+      settings:
+        repo: myregistry/myapp
+        tags: <+pipeline.sequenceId>
+        cosign_private_key: <+secrets.getValue("cosign_private_key")>
+        cosign_password: <+secrets.getValue("cosign_password")>
+        cosign_params: "-a harness_build=<+pipeline.sequenceId> -a harness_project=<+project.name>"
+```
+
+## Key Management
+
+### Generating Cosign Keys
+
+```bash
+# Generate a new key pair
+cosign generate-key-pair
+
+# This creates:
+# - cosign.key (private key) 
+# - cosign.pub (public key)
+```
+
+### Storing Keys Securely
+**Harness Secrets:**
+1. Go to Project Settings → Secrets
+2. Create new secret with type "File" for private key
+3. Create new secret with type "Text" for password
+
+## Security Features
+
+### Automatic Validation
+- ✅ **Private key format validation**: Ensures PEM format is correct
+- ✅ **Password requirement detection**: Warns if encrypted key needs password
+- ✅ **Keyless signing prevention**: Warns that OIDC keyless signing isn't supported
+
+### Error Handling
+- **Invalid private key**: `❌ Invalid private key format. Expected PEM format`
+- **Missing password**: `🔐 Encrypted private key requires password. Set PLUGIN_COSIGN_PASSWORD`
+- **Keyless signing**: `⚠️ WARNING: Keyless signing (OIDC) isn't supported yet in this plugin`
+
+## Signing Behavior
+
+### When Signing Occurs
+- ✅ **After each successful push**: Images are signed immediately after push
+- ✅ **Multiple tags**: Each tag gets signed individually
+- ✅ **Push-only mode**: Works with existing images
+- ✅ **Dry-run respect**: Skips signing in dry-run mode
+
+### Image References
+- **Preferred**: Signs by digest (e.g., `image@sha256:abc123...`) for security
+- **Fallback**: Signs by tag if digest unavailable
+
+### Authentication
+- **Registry auth**: Automatically uses existing Docker registry credentials
+
+## Verification
+
+To verify a signed image:
+
+```bash
+# Verify with public key
+cosign verify --key cosign.pub myregistry/myapp:latest
+
+# Verify with annotations
+cosign verify --key cosign.pub \
+  -a build_id=123 \
+  myregistry/myapp:latest
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **"cosign: command not found"**
+   - The container image includes cosign binary
+   - Use the latest plugin image: `plugins/docker:latest`
+
+2. **"keyless signing not supported"**
+   - This plugin only supports private key signing
+   - Don't use `--oidc` or `--identity-token` in `cosign_params`
+
+3. **"encrypted private key requires password"**
+   - Set `PLUGIN_COSIGN_PASSWORD` environment variable
+   - Or use an unencrypted private key
+
+4. **Registry authentication issues**
+   - Cosign uses the same Docker registry credentials
+   - Ensure Docker login is working first

--- a/cmd/drone-docker/main.go
+++ b/cmd/drone-docker/main.go
@@ -323,6 +323,22 @@ func main() {
 			Usage:  "access token",
 			EnvVar: "ACCESS_TOKEN",
 		},
+		// Cosign signing configuration
+		cli.StringFlag{
+			Name:   "cosign.private-key",
+			Usage:  "cosign private key content or file path for signing",
+			EnvVar: "PLUGIN_COSIGN_PRIVATE_KEY",
+		},
+		cli.StringFlag{
+			Name:   "cosign.password",
+			Usage:  "password for encrypted cosign private key",
+			EnvVar: "PLUGIN_COSIGN_PASSWORD",
+		},
+		cli.StringFlag{
+			Name:   "cosign.params",
+			Usage:  "additional cosign parameters (e.g., annotations, flags)",
+			EnvVar: "PLUGIN_COSIGN_PARAMS",
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -398,6 +414,11 @@ func run(c *cli.Context) error {
 		BaseImageRegistry: c.String("docker.baseimageregistry"),
 		BaseImageUsername: c.String("docker.baseimageusername"),
 		BaseImagePassword: c.String("docker.baseimagepassword"),
+		Cosign: docker.CosignConfig{
+			PrivateKey: c.String("cosign.private-key"),
+			Password:   c.String("cosign.password"),
+			Params:     c.String("cosign.params"),
+		},
 	}
 
 	if c.Bool("tags.auto") {

--- a/daemon.go
+++ b/daemon.go
@@ -11,6 +11,7 @@ import (
 const dockerExe = "/usr/local/bin/docker"
 const dockerdExe = "/usr/local/bin/dockerd"
 const dockerHome = "/root/.docker/"
+const cosignExe = "/usr/local/bin/cosign"
 
 func (p Plugin) startDaemon() {
 	cmd := commandDaemon(p.Daemon)

--- a/daemon_win.go
+++ b/daemon_win.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package docker
@@ -5,6 +6,7 @@ package docker
 const dockerExe = "C:\\bin\\docker.exe"
 const dockerdExe = ""
 const dockerHome = "C:\\ProgramData\\docker\\"
+const cosignExe = "C:\\bin\\cosign.exe"
 
 func (p Plugin) startDaemon() {
 	// this is a no-op on windows

--- a/docker.go
+++ b/docker.go
@@ -843,13 +843,10 @@ func commandCosignSign(build Build, tag string, cosign CosignConfig) *exec.Cmd {
 		args = append(args, "--key", cosign.PrivateKey)
 	}
 
-	// Set password and non-interactive environment variables
+	// Set password environment variable if provided
 	if cosign.Password != "" {
 		os.Setenv("COSIGN_PASSWORD", cosign.Password)
 	}
-
-	// Set COSIGN_YES for additional non-interactive assurance
-	os.Setenv("COSIGN_YES", "true")
 
 	// Add custom parameters (after our defaults so users can override)
 	if cosign.Params != "" {

--- a/docker.go
+++ b/docker.go
@@ -711,19 +711,36 @@ func GetDroneDockerExecCmd() string {
 }
 
 func getDigest(buildName string) (string, error) {
-	cmd := exec.Command("docker", "inspect", "--format='{{index .RepoDigests 0}}'", buildName)
+	cmd := exec.Command("docker", "inspect", "--format={{index .RepoDigests 0}}", buildName)
 	output, err := cmd.Output()
 	if err != nil {
 		return "", err
 	}
 
 	// Parse the output to extract the repo digest.
-	digest := strings.Trim(string(output), "'\n")
+	digest := strings.Trim(string(output), "\n")
 	parts := strings.Split(digest, "@")
 	if len(parts) > 1 {
 		return parts[1], nil
 	}
 	return "", errors.New("unable to fetch digest")
+}
+
+// getDigestFromRegistry gets the digest of a pushed image from the registry
+func getDigestFromRegistry(image string) (string, error) {
+	cmd := exec.Command(dockerExe, "inspect", "--format={{index .RepoDigests 0}}", image)
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	// Parse the output to extract the repo digest.
+	digest := strings.Trim(string(output), "\n")
+	parts := strings.Split(digest, "@")
+	if len(parts) > 1 {
+		return parts[1], nil
+	}
+	return "", errors.New("unable to fetch digest from registry")
 }
 
 // shouldSignWithCosign determines if cosign signing should be performed
@@ -791,10 +808,11 @@ func isValidPEMKey(pemContent string) bool {
 
 // commandCosignSign creates the cosign sign command
 func commandCosignSign(build Build, tag string, cosign CosignConfig) *exec.Cmd {
-	// Get image digest for secure signing
-	digest, err := getDigest(build.TempTag)
+	// Try to get image digest from the pushed image for secure signing
+	pushedImageRef := fmt.Sprintf("%s:%s", build.Repo, tag)
+	digest, err := getDigestFromRegistry(pushedImageRef)
 	if err != nil {
-		fmt.Printf("⚠️  WARNING: Could not get image digest for cosign signing: %s\n", err)
+		fmt.Printf("⚠️  WARNING: Could not get image digest from registry: %s\n", err)
 		fmt.Println("   Falling back to tag-based signing")
 		digest = ""
 	}
@@ -802,37 +820,38 @@ func commandCosignSign(build Build, tag string, cosign CosignConfig) *exec.Cmd {
 	// Construct image reference
 	var imageRef string
 	if digest != "" {
-		imageRef = fmt.Sprintf("%s:%s@%s", build.Repo, tag, digest)
+		imageRef = fmt.Sprintf("%s@%s", build.Repo, digest)
 		fmt.Printf("🔐 Signing image by digest: %s\n", imageRef)
 	} else {
-		imageRef = fmt.Sprintf("%s:%s", build.Repo, tag)
+		imageRef = pushedImageRef
 		fmt.Printf("🔐 Signing image by tag: %s\n", imageRef)
 	}
 
-	args := []string{"sign"}
+	// Start with base sign command and non-interactive flag
+	args := []string{"sign", "--yes"}
+
+	// Note: Transparency log upload is enabled by default
+	// Users can disable with --tlog-upload=false in cosign.Params if needed
 
 	// Handle private key (content vs file path)
 	if strings.HasPrefix(cosign.PrivateKey, "-----BEGIN") {
 		// PEM content - use environment variable method
 		args = append(args, "--key", "env://COSIGN_PRIVATE_KEY")
 		os.Setenv("COSIGN_PRIVATE_KEY", cosign.PrivateKey)
-		fmt.Println("🔑 Using private key from environment variable")
-
-		// Note: Environment variables will be cleaned up when process exits
-		// For long-running processes, consider manual cleanup after all signing is done
 	} else {
 		// File path method
 		args = append(args, "--key", cosign.PrivateKey)
-		fmt.Printf("🔑 Using private key from file: %s\n", cosign.PrivateKey)
 	}
 
-	// Set password environment variable
+	// Set password and non-interactive environment variables
 	if cosign.Password != "" {
 		os.Setenv("COSIGN_PASSWORD", cosign.Password)
-		fmt.Println("🔐 Password provided for private key")
 	}
 
-	// Add custom parameters
+	// Set COSIGN_YES for additional non-interactive assurance
+	os.Setenv("COSIGN_YES", "true")
+
+	// Add custom parameters (after our defaults so users can override)
 	if cosign.Params != "" {
 		extraArgs := strings.Fields(cosign.Params)
 		args = append(args, extraArgs...)
@@ -842,5 +861,7 @@ func commandCosignSign(build Build, tag string, cosign CosignConfig) *exec.Cmd {
 	// Add image reference
 	args = append(args, imageRef)
 
-	return exec.Command(cosignExe, args...)
+	cmd := exec.Command(cosignExe, args...)
+	fmt.Printf("🚀 Executing: %s %s\n", cosignExe, strings.Join(args, " "))
+	return cmd
 }

--- a/docker.go
+++ b/docker.go
@@ -727,7 +727,7 @@ func GetDroneDockerExecCmd() string {
 }
 
 func getDigest(buildName string) (string, error) {
-	cmd := exec.Command("docker", "inspect", "--format='{{index .RepoDigests 0}}'", buildName)
+	cmd := exec.Command(dockerExe, "inspect", "--format='{{index .RepoDigests 0}}'", buildName)
 	output, err := cmd.Output()
 	if err != nil {
 		return "", err

--- a/docker/docker/Dockerfile.linux.amd64
+++ b/docker/docker/Dockerfile.linux.amd64
@@ -3,7 +3,7 @@ FROM docker:28.1.1-dind
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 
 # Install cosign for container image signing
-RUN wget -O /usr/local/bin/cosign https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64 \
+RUN wget -O /usr/local/bin/cosign https://github.com/sigstore/cosign/releases/download/v2.5.3/cosign-linux-amd64 \
     && chmod +x /usr/local/bin/cosign
 
 ADD release/linux/amd64/drone-docker /bin/

--- a/docker/docker/Dockerfile.linux.amd64
+++ b/docker/docker/Dockerfile.linux.amd64
@@ -2,5 +2,9 @@ FROM docker:28.1.1-dind
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 
+# Install cosign for container image signing
+RUN wget -O /usr/local/bin/cosign https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64 \
+    && chmod +x /usr/local/bin/cosign
+
 ADD release/linux/amd64/drone-docker /bin/
 ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh", "/bin/drone-docker"]

--- a/docker/docker/Dockerfile.linux.arm64
+++ b/docker/docker/Dockerfile.linux.arm64
@@ -2,5 +2,9 @@ FROM arm64v8/docker:28.1.1-dind
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 
+# Install cosign for container image signing
+RUN wget -O /usr/local/bin/cosign https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-arm64 \
+    && chmod +x /usr/local/bin/cosign
+
 ADD release/linux/arm64/drone-docker /bin/
 ENTRYPOINT ["/usr/local/bin/dockerd-entrypoint.sh", "/bin/drone-docker"]

--- a/docker/docker/Dockerfile.linux.arm64
+++ b/docker/docker/Dockerfile.linux.arm64
@@ -3,7 +3,7 @@ FROM arm64v8/docker:28.1.1-dind
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 
 # Install cosign for container image signing
-RUN wget -O /usr/local/bin/cosign https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-arm64 \
+RUN wget -O /usr/local/bin/cosign https://github.com/sigstore/cosign/releases/download/v2.5.3/cosign-linux-arm64 \
     && chmod +x /usr/local/bin/cosign
 
 ADD release/linux/arm64/drone-docker /bin/

--- a/docker/docker/Dockerfile.windows.amd64.1809
+++ b/docker/docker/Dockerfile.windows.amd64.1809
@@ -26,7 +26,7 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
 RUN mkdir C:\bin
 
 # Install cosign for container image signing
-RUN powershell -Command "Invoke-WebRequest 'https://github.com/sigstore/cosign/releases/latest/download/cosign-windows-amd64.exe' -OutFile 'C:\bin\cosign.exe'"
+RUN Invoke-WebRequest 'https://github.com/sigstore/cosign/releases/latest/download/cosign-windows-amd64.exe' -OutFile 'C:\bin\cosign.exe' -UseBasicParsing
 
 COPY --from=download /windows/system32/netapi32.dll /windows/system32/netapi32.dll
 COPY --from=download /app/docker.exe C:/bin/docker.exe

--- a/docker/docker/Dockerfile.windows.amd64.1809
+++ b/docker/docker/Dockerfile.windows.amd64.1809
@@ -26,8 +26,7 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
 RUN mkdir C:\bin
 
 # Install cosign for container image signing
-RUN powershell -Command \
-    "Invoke-WebRequest 'https://github.com/sigstore/cosign/releases/latest/download/cosign-windows-amd64.exe' -OutFile 'C:\bin\cosign.exe'"
+RUN powershell -Command "Invoke-WebRequest 'https://github.com/sigstore/cosign/releases/latest/download/cosign-windows-amd64.exe' -OutFile 'C:\bin\cosign.exe'"
 
 COPY --from=download /windows/system32/netapi32.dll /windows/system32/netapi32.dll
 COPY --from=download /app/docker.exe C:/bin/docker.exe

--- a/docker/docker/Dockerfile.windows.amd64.1809
+++ b/docker/docker/Dockerfile.windows.amd64.1809
@@ -26,7 +26,7 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
 RUN mkdir C:\bin
 
 # Install cosign for container image signing
-RUN Invoke-WebRequest 'https://github.com/sigstore/cosign/releases/latest/download/cosign-windows-amd64.exe' -OutFile 'C:\bin\cosign.exe' -UseBasicParsing
+ADD https://github.com/sigstore/cosign/releases/download/v2.5.3/cosign-windows-amd64.exe C:/bin/cosign.exe
 
 COPY --from=download /windows/system32/netapi32.dll /windows/system32/netapi32.dll
 COPY --from=download /app/docker.exe C:/bin/docker.exe

--- a/docker/docker/Dockerfile.windows.amd64.1809
+++ b/docker/docker/Dockerfile.windows.amd64.1809
@@ -24,6 +24,11 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
   org.label-schema.schema-version="1.0"
 
 RUN mkdir C:\bin
+
+# Install cosign for container image signing
+RUN powershell -Command \
+    "Invoke-WebRequest 'https://github.com/sigstore/cosign/releases/latest/download/cosign-windows-amd64.exe' -OutFile 'C:\bin\cosign.exe'"
+
 COPY --from=download /windows/system32/netapi32.dll /windows/system32/netapi32.dll
 COPY --from=download /app/docker.exe C:/bin/docker.exe
 ADD release/windows/amd64/drone-docker.exe C:/bin/drone-docker.exe

--- a/docker/docker/Dockerfile.windows.amd64.ltsc2022
+++ b/docker/docker/Dockerfile.windows.amd64.ltsc2022
@@ -22,6 +22,11 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
   org.label-schema.schema-version="1.0"
 
 RUN mkdir C:\bin
+
+# Install cosign for container image signing
+RUN powershell -Command \
+    "Invoke-WebRequest 'https://github.com/sigstore/cosign/releases/latest/download/cosign-windows-amd64.exe' -OutFile 'C:\bin\cosign.exe'"
+
 COPY --from=download /windows/system32/netapi32.dll /windows/system32/netapi32.dll
 COPY --from=download /app/docker.exe C:/bin/docker.exe
 ADD release/windows/amd64/drone-docker.exe C:/bin/drone-docker.exe

--- a/docker/docker/Dockerfile.windows.amd64.ltsc2022
+++ b/docker/docker/Dockerfile.windows.amd64.ltsc2022
@@ -24,7 +24,7 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
 RUN mkdir C:\bin
 
 # Install cosign for container image signing
-RUN Invoke-WebRequest 'https://github.com/sigstore/cosign/releases/latest/download/cosign-windows-amd64.exe' -OutFile 'C:\bin\cosign.exe' -UseBasicParsing
+ADD https://github.com/sigstore/cosign/releases/download/v2.5.3/cosign-windows-amd64.exe C:/bin/cosign.exe
 
 COPY --from=download /windows/system32/netapi32.dll /windows/system32/netapi32.dll
 COPY --from=download /app/docker.exe C:/bin/docker.exe

--- a/docker/docker/Dockerfile.windows.amd64.ltsc2022
+++ b/docker/docker/Dockerfile.windows.amd64.ltsc2022
@@ -24,7 +24,7 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
 RUN mkdir C:\bin
 
 # Install cosign for container image signing
-RUN powershell -Command "Invoke-WebRequest 'https://github.com/sigstore/cosign/releases/latest/download/cosign-windows-amd64.exe' -OutFile 'C:\bin\cosign.exe'"
+RUN Invoke-WebRequest 'https://github.com/sigstore/cosign/releases/latest/download/cosign-windows-amd64.exe' -OutFile 'C:\bin\cosign.exe' -UseBasicParsing
 
 COPY --from=download /windows/system32/netapi32.dll /windows/system32/netapi32.dll
 COPY --from=download /app/docker.exe C:/bin/docker.exe

--- a/docker/docker/Dockerfile.windows.amd64.ltsc2022
+++ b/docker/docker/Dockerfile.windows.amd64.ltsc2022
@@ -24,8 +24,7 @@ LABEL maintainer="Drone.IO Community <drone-dev@googlegroups.com>" `
 RUN mkdir C:\bin
 
 # Install cosign for container image signing
-RUN powershell -Command \
-    "Invoke-WebRequest 'https://github.com/sigstore/cosign/releases/latest/download/cosign-windows-amd64.exe' -OutFile 'C:\bin\cosign.exe'"
+RUN powershell -Command "Invoke-WebRequest 'https://github.com/sigstore/cosign/releases/latest/download/cosign-windows-amd64.exe' -OutFile 'C:\bin\cosign.exe'"
 
 COPY --from=download /windows/system32/netapi32.dll /windows/system32/netapi32.dll
 COPY --from=download /app/docker.exe C:/bin/docker.exe


### PR DESCRIPTION
Adds container image signing capability using Cosign directly within the drone-docker plugin. Now supports signing images using their immutable digests with proper fallback to tag-based signing.

New Inputs:
- PLUGIN_COSIGN_PRIVATE_KEY: Private key content (PEM) or file path
- PLUGIN_COSIGN_PASSWORD: Optional password for encrypted keys
- PLUGIN_COSIGN_PARAMS: Optional additional cosign parameters

Features:
- Signs using immutable digest references (repo@sha256:digest) for better security
- Falls back to tag-based signing if digest unavailable
- Non-interactive operation with COSIGN_YES=true
- Handles both embedded PEM keys and file paths
- Signs after push completes, ensuring registry digest is used

Testing:

https://github.com/user-attachments/assets/ea2383a3-0a53-4af3-8208-e34a128c9b9d


