### PR TITLE
feat: [CI-21939]: update docker version

### DIFF
--- a/docker/docker/Dockerfile.linux.amd64
+++ b/docker/docker/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM docker:28.1.1-dind
+FROM docker:29.3.1-dind
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 

--- a/docker/docker/Dockerfile.linux.arm64
+++ b/docker/docker/Dockerfile.linux.arm64
@@ -1,4 +1,4 @@
-FROM arm64v8/docker:28.1.1-dind
+FROM arm64v8/docker:29.3.1-dind
 
 ENV DOCKER_HOST=unix:///var/run/docker.sock
 


### PR DESCRIPTION
Updating latest docker in docker. 
We are seeing an issue with the latest 6.18 linux kernel:

```shell
latest: Pulling from plugins/gcr
Digest: sha256:6d47e0f5c7f3e23018d9d9235129ed2df47f7ab67a2fa566aba33176fe52dd56
Status: Downloaded newer image for plugins/gcr:latest
+ /usr/local/bin/dockerd --data-root /var/lib/docker --host=unix:///var/run/docker.sock --dns 10.248.2.2
Unable to reach Docker Daemon after 15 attempts.
```