### PR TITLE
Fail fast when Docker daemon is unreachable

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -142,6 +142,13 @@ func (p Plugin) Exec() error {
 	if maxRetries <= 0 {
 		maxRetries = 15 // default value
 	}
+	// If the daemon still isn't reachable after max retries, fail fast.
+	//
+	// Historically this code only printed an error and continued, which led to
+	// confusing follow-up failures like:
+	//   "Cannot connect to the Docker daemon at unix:///var/run/docker.sock"
+	//
+	// See: https://github.com/drone-plugins/drone-docker/issues/414
 	for i := 0; ; i++ {
 		cmd := commandInfo()
 		err := cmd.Run()
@@ -149,8 +156,7 @@ func (p Plugin) Exec() error {
 			break
 		}
 		if i == maxRetries {
-			fmt.Printf("Unable to reach Docker Daemon after %d attempts.\n", maxRetries)
-			break
+			return fmt.Errorf("unable to reach Docker Daemon after %d attempts", maxRetries)
 		}
 		time.Sleep(time.Second * 1)
 	}


### PR DESCRIPTION
Fixes #414.

When the plugin cannot reach the Docker daemon after the configured retry count, return an error instead of printing a message and continuing. This prevents confusing follow-up errors like "Cannot connect to the Docker daemon at unix:///var/run/docker.sock".
